### PR TITLE
Release 1.1.0 changes

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -19,15 +19,15 @@ This project implements the <strong>Dynamic SOLO (SOLOv2)</strong> variant:
 
 ## Who This Project is For
 
-This is <strong>not a production-ready</strong> project. It is primarily intended for educational purposes—especially for individuals without high-performance GPUs who are interested in learning about computer vision and the SOLO model. We chose TensorFlow to make the implementation accessible. The code is thoroughly documented to ensure clarity and ease of understanding.
+It is primarily intended for educational purposes—especially for individuals without high-performance GPUs who are interested in learning about computer vision and the SOLO model. We chose TensorFlow to make the implementation accessible. The code is thoroughly documented to ensure clarity and ease of understanding. However, the code is well optimized for use in production-ready tasks.
 
 ## Installation, Dependencies, and Requirements
 
-- Python 3.11 is required.
+- Python 3.12.3 is required.
 - All dependencies are listed in `requirements.txt`.
 - Use `setup.sh` to install all dependencies on Linux.
 
-The project has been tested on <strong>Ubuntu 24.04.2 LTS</strong> with <strong>TensorFlow 2.15.0.post1</strong>. It may work on other operating systems and TensorFlow versions (older than 2.15.0.post1), but we cannot guarantee compatibility.
+The project has been tested on <strong>Ubuntu 24.04.2 LTS</strong> with <strong>nvcr.io/nvidia/tensorflow:25.02-tf2-py3 container using TensorFlow 2.17.0</strong>. It may work on other operating systems and TensorFlow versions (older than 2.17.0), but we cannot guarantee compatibility.
 
 > <strong>Note:</strong> A GPU with CUDA support is highly recommended to speed up training. The project currently does not support multi-GPU training.
 
@@ -35,6 +35,21 @@ The project has been tested on <strong>Ubuntu 24.04.2 LTS</strong> with <strong>
 
 The code supports datasets in the COCO format. We recommend creating your own dataset to better understand the full training cycle, including data preparation. [LabelMe](https://github.com/wkentaro/labelme) is a good tool for this. You don’t need a large dataset or many classes to begin training and see results. This makes it easier to experiment and learn without requiring powerful hardware.  
 Alternatively, you can use the original [COCO dataset](https://cocodataset.org/#home), which contains 80 object categories.
+
+For high-performance tasks we recommend using the dataset generator from `coco_dataset_optimized.py`. The dataset interacts with TFRecord format files using parallel reading and compatible with TensorFlow Graph Mode. To use the dataset, follow these steps:
+1) Convert your COCO dataset to TFRecord files:
+```
+python convert_coco_to_tfrecord.py \
+  --images_root /path/to/images \
+  --annotations /path/to/instances_train.json \
+  --output /path/to/out/train.tfrecord \
+  --num_shards 4
+```
+2) Set corresponding settings in `config.py` file:
+```
+self.use_optimized_dataset = True
+self.tfrecord_dataset_directory_path = 'path/to/tfrecords/directory'
+```
 
 ## Configuration
 
@@ -134,7 +149,7 @@ It is possible to evaluate the data fed to the model before training to ensure t
 python test_dataset.py
 ```
 
-This script generates one image per instance (i.e., per object and its mask) categorized and scaled. The outputs are saved in `images/dataset_test`.
+This script generates images with instance masks and their corresponding category labels. The outputs are saved in `images/dataset_test`.
 
 By default, it processes the first 20 images. To change or remove this limit, edit `test_dataset.py`:
 

--- a/coco_dataset_optimized.py
+++ b/coco_dataset_optimized.py
@@ -1,0 +1,742 @@
+"""
+Author: Pavel Timonin
+Created: 2025-10-17
+Description: This script contains classes and functions of COCO dataset optimized for tf.Dataset.
+"""
+
+
+import os
+from typing import Optional, Tuple
+from coco_dataset import compute_scale_ranges
+
+import tensorflow as tf
+
+# Feature spec that matches the COCO TFRecord format
+_FEATURES = {
+    # image-level fields
+    "image/encoded": tf.io.FixedLenFeature([], tf.string),
+    "image/height": tf.io.FixedLenFeature([], tf.int64),
+    "image/width": tf.io.FixedLenFeature([], tf.int64),
+    "image/filename": tf.io.FixedLenFeature([], tf.string),
+    "image/id": tf.io.FixedLenFeature([], tf.int64),
+    "image/format": tf.io.FixedLenFeature([], tf.string),
+
+    # per-object fields
+    "image/object/bbox/xmin": tf.io.VarLenFeature(tf.float32),
+    "image/object/bbox/ymin": tf.io.VarLenFeature(tf.float32),
+    "image/object/bbox/xmax": tf.io.VarLenFeature(tf.float32),
+    "image/object/bbox/ymax": tf.io.VarLenFeature(tf.float32),
+    "image/object/area": tf.io.VarLenFeature(tf.float32),
+    "image/object/category_id": tf.io.VarLenFeature(tf.int64),
+    "image/object/iscrowd": tf.io.VarLenFeature(tf.int64),
+    "image/object/mask_png": tf.io.VarLenFeature(tf.string),
+}
+
+@tf.function
+def process_one(
+        cate_grid, mask_tensor, seg_mask_orig, bbox, cat_id,
+        height_scale, width_scale, cell_h, cell_w,
+        grid_size_t, feat_h_t, feat_w_t, center_radius_t, scale_min_t, scale_max_t
+):
+    """
+    Assigns a category to a neighborhood of SOLO grid cells around an object's center
+    and writes the object's binary mask into the corresponding mask channels.
+
+    This op:
+      1) Filters the object by its scale using sqrt(area) ∈ [scale_min_t, scale_max_t).
+      2) Computes the center of mass (COM) of `seg_mask_orig` in the original image space.
+      3) Maps the COM to the feature-map (FPN) grid and selects a (2r+1)×(2r+1) neighborhood
+         of grid cells around it (where r = `center_radius_t`).
+      4) For cells that are currently unassigned (value == -1), sets the category to `cat_id`
+         in `cate_grid` and writes the resized binary mask into the corresponding mask
+         channels of `mask_tensor`.
+
+    Args:
+        cate_grid (tf.Tensor): Shape `[S, S]`, dtype `tf.int32`. Category target grid for a
+            single scale. Unassigned cells must contain `-1`.
+        mask_tensor (tf.Tensor): Shape `[H, W, S*S]`, dtype `tf.uint8`. Per-cell binary masks
+            for the same SOLO grid. Channel `c = gy * S + gx` corresponds to grid cell `(gy, gx)`.
+        seg_mask_orig (tf.Tensor): Shape `[img_h, img_w]` (or `[img_h, img_w, 1]`), integer/bool.
+            Foreground is values `> 0`. Used to compute the COM and as the source for the mask.
+        bbox (tf.Tensor): Shape `[4]`, dtype `tf.float32`. Bounding box `[x, y, w, h]` in the
+            original image coordinate space; used only to compute `area = w*h` for scale filtering.
+        cat_id (tf.Tensor or int): Scalar `int32`. The category ID to assign to eligible cells.
+        height_scale (tf.Tensor or float): Scalar `float32`. Factor to map original `y` to FPN `y`
+            (typically `feat_h / img_h`).
+        width_scale (tf.Tensor or float): Scalar `float32`. Factor to map original `x` to FPN `x`
+            (typically `feat_w / img_w`).
+        cell_h (tf.Tensor or float): Scalar `float32`. Height of one SOLO cell in FPN pixels.
+        cell_w (tf.Tensor or float): Scalar `float32`. Width of one SOLO cell in FPN pixels.
+        grid_size_t (tf.Tensor or int): Scalar `int32`. SOLO grid size `S`.
+        feat_h_t (tf.Tensor or int): Scalar `int32`. Feature-map height `H` for mask resizing.
+        feat_w_t (tf.Tensor or int): Scalar `int32`. Feature-map width `W` for mask resizing.
+        center_radius_t (tf.Tensor or int): Scalar `int32`. Radius `r` of the neighborhood (in cells)
+            around the COM to consider: offsets in `[-r, r]` for both x and y.
+        scale_min_t (tf.Tensor or float): Scalar `float32`. Minimum allowed `sqrt(area)` (inclusive).
+        scale_max_t (tf.Tensor or float): Scalar `float32`. Maximum allowed `sqrt(area)` (exclusive).
+
+    Returns:
+        Tuple[tf.Tensor, tf.Tensor]:
+            - cate_grid_out (tf.Tensor): Shape `[S, S]`, dtype `tf.int32`. Updated category grid.
+            - mask_tensor_out (tf.Tensor): Shape `[H, W, S*S]`, dtype `tf.uint8`. Updated mask tensor
+              with the resized `seg_mask_orig` written into channels for newly assigned cells.
+
+    Behavior:
+        - If `sqrt(area)` is outside `[scale_min_t, scale_max_t)`, inputs are returned unchanged.
+        - If `seg_mask_orig` has no foreground pixels, inputs are returned unchanged.
+        - Only cells whose current value is `-1` are updated; pre-assigned cells are left intact.
+        - Masks are resized to `[feat_h_t, feat_w_t]` using nearest-neighbor interpolation.
+        - For each newly assigned cell `(gy, gx)`, the mask is written into channel
+          `c = gy * S + gx`.
+
+    Notes:
+        - `mask_tensor` must be `tf.uint8` to match the resized binary mask produced here.
+        - Coordinate mapping:
+            COM (orig) → FPN: `x_fpn = x_mean * width_scale`, `y_fpn = y_mean * height_scale`
+            Center cell indices: `gx = floor(x_fpn / cell_w)`, `gy = floor(y_fpn / cell_h)`,
+            each clipped to `[0, S-1]`.
+    """
+    # Unpack bbox
+    x, y, w, h = bbox[0], bbox[1], bbox[2], bbox[3]
+
+    # Filter by area/scale range
+    area = w * h
+    def _skip():
+        return cate_grid, mask_tensor
+
+    def _go():
+        # Center of mass (original space) from mask > 0
+        coords = tf.where(seg_mask_orig > 0)
+        n_pts = tf.shape(coords)[0]
+        def _empty():
+            return cate_grid, mask_tensor
+        def _non_empty():
+            # y,x means row,col
+            y_mean = tf.reduce_mean(tf.cast(coords[:, 0], tf.float32))
+            x_mean = tf.reduce_mean(tf.cast(coords[:, 1], tf.float32))
+
+            # Map COM to FPN space
+            x_fpn = x_mean * width_scale
+            y_fpn = y_mean * height_scale
+
+            # Center cell indices
+            gx_center = tf.cast(tf.math.floor(x_fpn / cell_w), tf.int32)
+            gy_center = tf.cast(tf.math.floor(y_fpn / cell_h), tf.int32)
+            gx_center = tf.clip_by_value(gx_center, 0, grid_size_t - 1)
+            gy_center = tf.clip_by_value(gy_center, 0, grid_size_t - 1)
+
+            # Resize mask to feature map (nearest)
+            # Ensure shape [H,W]
+            seg = tf.cast(seg_mask_orig > 0, tf.uint8)
+            seg = tf.image.resize(
+                tf.expand_dims(seg, axis=-1),  # [H0,W0,1]
+                size=(feat_h_t, feat_w_t),
+                method=tf.image.ResizeMethod.NEAREST_NEIGHBOR,
+                preserve_aspect_ratio=False,
+                antialias=False
+            )
+            seg = tf.squeeze(tf.cast(seg, tf.uint8), axis=-1)  # [H,W]
+
+            # Neighborhood offsets in a vectorized way
+            r = center_radius_t
+            rng = tf.range(-r, r + 1, dtype=tf.int32)
+            dx, dy = tf.meshgrid(rng, rng, indexing='xy')
+            dx = tf.reshape(dx, [-1])  # [K]
+            dy = tf.reshape(dy, [-1])  # [K]
+            gx = tf.clip_by_value(gx_center + dx, 0, grid_size_t - 1)
+            gy = tf.clip_by_value(gy_center + dy, 0, grid_size_t - 1)
+            neigh_indices = tf.stack([gy, gx], axis=-1)  # [K,2]
+
+            # Current values at neighbor cells
+            current_vals = tf.gather_nd(cate_grid, neigh_indices)  # [K]
+            is_free = tf.equal(current_vals, -1)
+
+            # Cells we will actually assign (only the free ones)
+            # Build updates for category grid
+            k = tf.shape(neigh_indices)[0]
+            cat_updates = tf.fill([k], cat_id)
+            # But only for free cells; otherwise keep current
+            final_updates = tf.where(is_free, cat_updates, current_vals)
+
+            # Update cate_grid via scatter
+            new_cate_grid = tf.tensor_scatter_nd_update(
+                cate_grid, neigh_indices, final_updates
+            )
+
+            # Mask updates only for newly assigned channels
+            new_cells_indices = tf.boolean_mask(neigh_indices, is_free)  # [K_free,2]
+            new_channels = new_cells_indices[:, 0] * grid_size_t + new_cells_indices[:, 1]  # [K_free]
+            k_free = tf.shape(new_channels)[0]
+
+            def _update_masks():
+                # Make a channel boolean mask [C] with True for channels to update
+                onehot = tf.one_hot(new_channels, depth=grid_size_t * grid_size_t, dtype=tf.int32)
+                onehot = tf.cast(onehot, tf.bool)
+                ch_mask = tf.reduce_any(onehot, axis=0)  # [C] bool
+
+                # Broadcast channel mask to [H,W,C]
+                ch_mask_b = tf.reshape(ch_mask, [1, 1, -1])
+                ch_mask_b = tf.broadcast_to(ch_mask_b, tf.shape(mask_tensor))
+
+                # Broadcast seg to [H,W,1]
+                seg_b = tf.expand_dims(seg, axis=-1)
+                seg_b = tf.broadcast_to(seg_b, tf.shape(mask_tensor))
+
+                # Replace only at target channels
+                updated_mask = tf.where(ch_mask_b, seg_b, mask_tensor)
+                return updated_mask
+
+            new_mask_tensor = tf.cond(
+                tf.greater(k_free, 0),
+                true_fn=_update_masks,
+                false_fn=lambda: mask_tensor
+            )
+
+            return new_cate_grid, new_mask_tensor
+
+        return tf.cond(tf.equal(n_pts, 0), _empty, _non_empty)
+
+    in_scale = tf.logical_and(
+        tf.greater(area, 0.0),
+        tf.logical_and(
+            tf.greater_equal(tf.sqrt(area), scale_min_t),
+            tf.less(tf.sqrt(area), scale_max_t)
+        )
+    )
+    return tf.cond(in_scale, _go, _skip)
+
+@tf.function
+def generate_solo_targets_single_scale(
+    categories,
+    resized_masks,
+    resized_bboxes,
+    target_height,
+    target_width,
+    grid_size,
+    scale_range,     # (scale_min, scale_max) for sqrt(area), e.g. (0, 64)
+    scale=0.25,      # scale factor for feature map size (default 1/4)
+    center_radius=0  # radius (in grid cells) around center to assign
+):
+    """
+    Builds SOLO targets (category grid and per-cell masks) for one grid scale.
+
+    Given per-instance categories, masks, and boxes already resized to the target
+    training dimensions, this function:
+      * Computes the feature-map size from `scale`.
+      * Initializes empty targets (category grid filled with -1, mask channels 0).
+      * Iterates over instances and calls `process_one` to assign categories
+        and write mask channels within a neighborhood of the instance center.
+      * Returns per-scale targets.
+
+    Args:
+      categories: Tensor [N] (int32). Category id per instance.
+      resized_masks: Tensor [N, Ht, Wt] (uint8). Resized binary masks aligned to
+        `target_height` x `target_width`. Values are 0/1 (or 0/255 then cast).
+      resized_bboxes: Tensor [N, 4] (float32). Boxes in (x, y, w, h) format
+        aligned to the same target space as `resized_masks`.
+      target_height: Scalar int32. Target image height (Ht).
+      target_width: Scalar int32. Target image width (Wt).
+      grid_size: Scalar int32. SOLO grid size S for this scale.
+      scale_range: Tensor/tuple [2] (float32). (min_sqrt_area, max_sqrt_area)
+        of instances to include at this scale.
+      scale: Scalar float (default 0.25). Feature-map scale relative to target
+        image size, used to compute feature resolution (Hf, Wf).
+      center_radius: Scalar int32 (default 0). Neighborhood radius in grid cells.
+
+    Returns:
+      Tuple[Tensor, Tensor]:
+        - cate_target: Tensor [S, S] (int32). Category grid with -1 for empty cells.
+        - mask_target: Tensor [Hf, Wf, S*S] (uint8). Concatenated per-cell masks.
+    """
+    scale_min = scale_range[0]
+    scale_max = scale_range[1]
+
+    # Compute feature map shape from scale
+    feat_h = tf.cast(tf.round(tf.cast(target_height, tf.float32) * scale), tf.int32)
+    feat_w = tf.cast(tf.round(tf.cast(target_width, tf.float32) * scale), tf.int32)
+
+    # Prepare empty targets
+    cate_target = tf.cast(tf.fill([grid_size, grid_size], -1), tf.int32)
+    mask_channels = grid_size * grid_size
+    mask_target = tf.zeros([feat_h, feat_w, mask_channels], dtype=tf.uint8)
+
+    # Precompute scales and cell sizes (as TF scalars)
+    cell_h = tf.cast(feat_h, tf.float32) / tf.cast(grid_size, tf.float32)
+    cell_w = tf.cast(feat_w, tf.float32) / tf.cast(grid_size, tf.float32)
+
+    def body(i, cate_target_changed, mask_target_changed):
+        cate_id = categories[i]
+        mask = resized_masks[i]
+        bbox = resized_bboxes[i]
+
+        cate_target_result, mask_target_result = process_one(cate_target_changed, mask_target_changed, mask, bbox,
+                                                             cate_id, scale, scale, cell_h, cell_w, grid_size, feat_h,
+                                                             feat_w, center_radius, scale_min, scale_max)
+
+        return i + 1, cate_target_result, mask_target_result
+
+    i0 = tf.constant(0)
+    i_f, cate_target, mask_target = tf.while_loop(
+        lambda i, c, m : i < tf.shape(categories)[0],
+        body,
+        loop_vars=[i0, cate_target, mask_target],
+    )
+
+    return cate_target, mask_target
+
+def sparse_to_dense_1d(v, dtype):
+    """
+    Convert a VarLen sparse tensor to a 1D dense tensor (length N).
+
+    Args:
+      v: `tf.SparseTensor`. A rank-1 sparse tensor.
+      dtype: `tf.DType`. The desired dtype of the output.
+
+    Returns:
+      Tensor: Dense 1D tensor with shape [N] and dtype `dtype`.
+    """
+    return tf.cast(tf.sparse.to_dense(v), dtype)
+
+# -----------------------------
+# Data augmentations (graph mode, TF-only)
+# -----------------------------
+def maybe_hflip(img, masks, bboxes):
+    """
+    Randomly applies a horizontal flip to image, masks, and boxes (p=0.5).
+
+    Args:
+      img: Tensor [H, W, C] (uint8). Image.
+      masks: Tensor [N, H, W] (uint8). Per-instance binary masks aligned to `img`.
+      bboxes: Tensor [N, 4] (float32). Boxes in (x, y, w, h) format in the same
+        coordinate space as `img`.
+
+    Returns:
+      Tuple[Tensor, Tensor, Tensor]:
+        - img_f: Tensor [H, W, C] (uint8). Possibly flipped image.
+        - masks_f: Tensor [N, H, W] (uint8). Possibly flipped masks.
+        - b_new: Tensor [N, 4] (float32). Updated boxes after flip.
+
+    Notes:
+      * Applies with probability 0.5.
+      * Boxes are mirrored around the image center by updating x: `x' = W - x - w`.
+    """
+    do = tf.less(tf.random.uniform([], 0, 1.0), 0.5)
+    def yes():
+        # Flip image and masks
+        img_f = tf.image.flip_left_right(img)
+        masks_f = tf.reverse(masks, axis=[2])  # [N,H,W], flip width
+
+        # Adjust boxes
+        W = tf.cast(tf.shape(img)[1], tf.float32)
+        x, y, bw, bh = tf.unstack(bboxes, axis=1)
+        x_new = W - x - bw
+        b_new = tf.stack([x_new, y, bw, bh], axis=1)
+        return img_f, masks_f, b_new
+    def no():
+        return img, masks, bboxes
+    return tf.cond(do, yes, no)
+
+def maybe_brightness(img):
+    """
+    Randomly jitters brightness by a multiplicative factor in [-20%, +20%] (p=0.5).
+
+    Args:
+      img: Tensor [H, W, C] (uint8). Image in range [0, 255].
+
+    Returns:
+      Tensor: Image of shape [H, W, C] (uint8) with brightness possibly adjusted.
+
+    Notes:
+      * Applies with probability 0.5.
+      * The factor is sampled uniformly from [0.8, 1.2] and values are clipped to [0, 255].
+    """
+    do = tf.less(tf.random.uniform([], 0, 1.0), 0.5)
+    def yes():
+        factor = 1.0 + (tf.random.uniform([], -0.2, 0.2))
+        img_f32 = tf.cast(img, tf.float32) * factor
+        img_f32 = tf.clip_by_value(img_f32, 0.0, 255.0)
+        return tf.cast(img_f32, tf.uint8)
+    def no():
+        return img
+    return tf.cond(do, yes, no)
+
+def maybe_scale(img, masks, bboxes):
+    """
+    Randomly scales image, masks, and boxes uniformly (p=0.5).
+
+    The scale factor `s` is sampled from [0.8, 1.2]. Images are resized with bilinear
+    interpolation; masks use nearest neighbor. Boxes are scaled by `s`.
+
+    Args:
+      img: Tensor [H, W, C] (uint8). Input image.
+      masks: Tensor [N, H, W] (uint8). Per-instance masks aligned with `img`.
+      bboxes: Tensor [N, 4] (float32). Boxes (x, y, w, h) in `img` coordinates.
+
+    Returns:
+      Tuple[Tensor, Tensor, Tensor]:
+        - img_rs: Tensor [⌊H*s⌉, ⌊W*s⌉, C] (uint8). Resized image.
+        - masks_rs: Tensor [N, ⌊H*s⌉, ⌊W*s⌉] (uint8). Resized masks.
+        - b_new: Tensor [N, 4] (float32). Scaled boxes.
+
+    Notes:
+      * Applies with probability 0.5.
+      * Image values are clipped to [0, 255] after bilinear resize and rounding.
+    """
+    do = tf.less(tf.random.uniform([], 0, 1.0), 0.5)
+    def yes():
+        s = tf.random.uniform([], 0.8, 1.2)
+
+        # New size
+        orig_hw = tf.cast(tf.shape(img)[:2], tf.float32)  # [H, W]
+        new_hw = tf.cast(tf.round(orig_hw * s), tf.int32)
+        new_h = new_hw[0]
+        new_w = new_hw[1]
+
+        # Resize image (bilinear) and masks (nearest)
+        img_f32 = tf.cast(img, tf.float32)
+        img_rs  = tf.image.resize(img_f32, size=[new_h, new_w], method=tf.image.ResizeMethod.BILINEAR)
+        img_rs  = tf.clip_by_value(img_rs, 0.0, 255.0)
+        img_rs  = tf.cast(tf.round(img_rs), tf.uint8)
+
+        # Resize all masks at once
+        masks_ch = tf.expand_dims(masks, axis=-1)                         # [N,H,W,1]
+        masks_rs = tf.image.resize(masks_ch, [new_h, new_w], method=tf.image.ResizeMethod.NEAREST_NEIGHBOR)
+        masks_rs = tf.squeeze(masks_rs, axis=-1)                             # [N,H,W]
+        masks_rs = tf.cast(masks_rs, tf.uint8)
+
+        # Scale boxes and areas
+        b_new = bboxes * tf.stack([s, s, s, s])  # (x,y,w,h) * s
+
+        return img_rs, masks_rs, b_new
+    def no():
+        return img, masks, bboxes
+    return tf.cond(do, yes, no)
+
+def maybe_random_crop(img, masks, bboxes, cat_ids):
+    """
+    Applies a random crop up to 20% per side, updating masks/boxes/categories (p=0.5).
+
+    A rectangular crop is sampled with left/top margins in [0, 0.2*W/H] and
+    right/bottom margins in [0, 0.2*W/H]. Boxes are translated to the crop
+    coordinate frame, clipped, and instances with very small resulting boxes
+    (<=1 px width or height) are removed. The function keeps `cat_ids` and `masks`
+    aligned with the filtered boxes.
+
+    Args:
+      img: Tensor [H, W, C] (uint8). Input image.
+      masks: Tensor [N, H, W] (uint8). Per-instance masks.
+      bboxes: Tensor [N, 4] (float32). Boxes (x, y, w, h) in image coords.
+      cat_ids: Tensor [N] (int32). Category id per instance.
+
+    Returns:
+      Tuple[Tensor, Tensor, Tensor, Tensor]:
+        - img_cr: Tensor [Hc, Wc, C] (uint8). Cropped image.
+        - m_new: Tensor [N', Hc, Wc] (uint8). Cropped masks for kept instances.
+        - b_new: Tensor [N', 4] (float32). Boxes translated/clipped to the crop.
+        - c_new: Tensor [N'] (int32). Category ids for kept instances.
+
+    Notes:
+      * Applies with probability 0.5.
+      * Keeps only boxes with width > 1 and height > 1 in pixels after cropping.
+    """
+    do = tf.less(tf.random.uniform([], 0, 1.0), 0.5)
+    def yes():
+        H = tf.shape(img)[0]
+        W = tf.shape(img)[1]
+        Hf = tf.cast(H, tf.float32)
+        Wf = tf.cast(W, tf.float32)
+
+        max_crop_x = tf.cast(tf.floor(Wf * 0.2), tf.int32)
+        max_crop_y = tf.cast(tf.floor(Hf * 0.2), tf.int32)
+
+        # Sample crop bounds: ensure left <= right and top <= bottom
+        x1 = tf.random.uniform([], minval=0,              maxval=max_crop_x + 1, dtype=tf.int32)
+        y1 = tf.random.uniform([], minval=0,              maxval=max_crop_y + 1, dtype=tf.int32)
+        x2 = tf.random.uniform([], minval=W - max_crop_x, maxval=W + 1,         dtype=tf.int32)
+        y2 = tf.random.uniform([], minval=H - max_crop_y, maxval=H + 1,         dtype=tf.int32)
+
+        crop_w = x2 - x1
+        crop_h = y2 - y1
+
+        # Crop image and masks
+        img_cr = tf.slice(img,   [y1, x1, 0], [crop_h, crop_w, -1])
+        masks_cr = tf.slice(masks, [0, y1, x1], [-1, crop_h, crop_w])  # [N, crop_h, crop_w]
+
+        # Adjust boxes to crop region, clip, and filter
+        x, y, bw, bh = tf.unstack(bboxes, axis=1)
+        x1f = tf.cast(x1, tf.float32)
+        y1f = tf.cast(y1, tf.float32)
+        cwf = tf.cast(crop_w, tf.float32)
+        chf = tf.cast(crop_h, tf.float32)
+
+        nx = tf.maximum(0.0, x - x1f)
+        ny = tf.maximum(0.0, y - y1f)
+        nw = tf.maximum(0.0, tf.minimum(bw, cwf - nx))
+        nh = tf.maximum(0.0, tf.minimum(bh, chf - ny))
+
+        keep = tf.logical_and(nw > 1.0, nh > 1.0)  # discard tiny/invalid boxes
+
+        # Apply mask to per-instance tensors
+        b_new = tf.boolean_mask(tf.stack([nx, ny, nw, nh], axis=1), keep)
+        c_new = tf.boolean_mask(cat_ids,   keep)
+        m_new = tf.boolean_mask(masks_cr,  keep, axis=0)
+
+
+        return img_cr, m_new, b_new, c_new
+    def no():
+        return img, masks, bboxes, cat_ids
+    return tf.cond(do, yes, no)
+
+
+def parse_example(
+        serialized,
+        target_height,
+        target_width,
+        grid_sizes,
+        scale,
+        scale_ranges,
+        augment):
+    """
+    Parses one TFRecord example and builds multi-scale SOLO training targets.
+
+    This function:
+      * Parses a single serialized example using `_FEATURES`.
+      * Decodes the image (to RGB if needed) and per-instance masks (PNG).
+      * Optionally applies augmentations (flip, brightness, random crop).
+      * Resizes image to `(target_height, target_width)` and masks via nearest.
+      * Scales boxes to the resized image coordinate frame.
+      * For each SOLO grid size and its corresponding `scale_range`, generates
+        per-scale targets via `generate_solo_targets_single_scale`, then
+        concatenates category targets (flattened per scale) and mask targets
+        (concatenated along channel axis).
+
+    Args:
+      serialized: Scalar string Tensor. A single serialized `tf.train.Example`.
+      target_height: Scalar int. Output image height.
+      target_width: Scalar int. Output image width.
+      grid_sizes: Tensor/array-like [num_scales] (int32). SOLO grid sizes per scale.
+      scale: Scalar float. Feature-map downscale (e.g., 0.25 -> 1/4).
+      scale_ranges: Tensor [num_scales, 2] (float32). Per-scale (min, max) for
+        sqrt(area) gating.
+      augment: Scalar bool. If True, apply data augmentations.
+
+    Returns:
+      Tuple[Tensor, Tensor, Tensor]:
+        - image_resized: Tensor [target_height, target_width, 3] (float32) in [0, 1].
+        - cate_targets: Tensor [sum(S_i^2)] (int32). Concatenated category
+          targets from all scales, flattened per scale then concatenated.
+        - mask_targets: Tensor [Hf, Wf, sum(S_i^2)] (uint8). Concatenated
+          per-cell masks across all scales. Hf/Wf match the feature size for the
+          provided `scale`.
+
+    Notes:
+      * If there are zero instances, shapes are still well-defined: category
+        targets will be a concatenation of -1-filled grids; mask targets will be
+        all zeros.
+    """
+
+    ex = tf.io.parse_single_example(serialized, _FEATURES)
+
+    # Scalars
+    height  = tf.cast(ex["image/height"],  tf.int32)
+    width   = tf.cast(ex["image/width"],   tf.int32)
+    img_enc = ex["image/encoded"]                  # bytes
+
+    scale_y = tf.cast(target_height, tf.float32) / tf.cast(height, tf.float32)
+    scale_x = tf.cast(target_width, tf.float32) / tf.cast(width, tf.float32)
+
+    # Variable-length (per-object) -> dense 1D tensors
+    xmin = sparse_to_dense_1d(ex["image/object/bbox/xmin"], tf.float32)
+    ymin = sparse_to_dense_1d(ex["image/object/bbox/ymin"], tf.float32)
+    xmax = sparse_to_dense_1d(ex["image/object/bbox/xmax"], tf.float32)
+    ymax = sparse_to_dense_1d(ex["image/object/bbox/ymax"], tf.float32)
+
+    x = xmin
+    y = ymin
+    w = (xmax - xmin)
+    h = (ymax - ymin)
+
+    cat_ids   = sparse_to_dense_1d(ex["image/object/category_id"], tf.int32)
+    mask_pngs = sparse_to_dense_1d(ex["image/object/mask_png"], tf.string)
+
+    # Stack boxes as [N, 4] in (x, y, w, h) format
+    bboxes = tf.stack([x, y, w, h], axis=1) if tf.size(xmin) > 0 else tf.zeros([0, 4], tf.float32)
+
+    # Decode image to ensure 3 channels
+    img = tf.io.decode_image(img_enc, expand_animations=False)  # uint8, shape [H,W,C]
+    # Ensure we have 3 channels (COCO images should be RGB)
+    img = tf.cond(tf.shape(img)[-1] == 3,
+                  lambda: img,
+                  lambda: tf.image.grayscale_to_rgb(img))
+
+    # Decode each per-object PNG into [H, W] uint8;
+    def _decode_one(png_bytes):
+        m = tf.io.decode_png(png_bytes, channels=1)  # [H,W,1]
+        return tf.squeeze(m, axis=-1)  # [H,W]
+
+    masks = tf.map_fn(_decode_one, mask_pngs, fn_output_signature=tf.uint8) # shape [N, H, W]
+
+    def _apply_augmentation():
+        # Horizontal flip
+        img_aug, masks_aug, bboxes_aug = maybe_hflip(img, masks, bboxes)
+
+        # Brightness jitter (+/-20%)
+        img_aug = maybe_brightness(img_aug)
+
+        # Random scaling (0.8x–1.2x)
+        #img_aug, masks_aug, bboxes_aug = maybe_scale(img_aug, masks_aug, bboxes_aug)
+
+        # Random crop (≤20% each side); updates and filters instance-aligned tensors
+        img_aug, masks_aug, bboxes_aug, cat_ids_aug = maybe_random_crop(
+            img_aug, masks_aug, bboxes_aug, cat_ids
+        )
+
+        return img_aug, masks_aug, bboxes_aug, cat_ids_aug
+
+    img, masks, bboxes, cat_ids = tf.cond(augment, _apply_augmentation, lambda: (img, masks, bboxes, cat_ids))
+
+    # Resize (bilinear by default; set method if you need a match)
+    image_resized = tf.image.resize(img, size=(target_height, target_width), method="bilinear", antialias=True)
+
+    # Convert to float32 in [0, 1]
+    image_resized = tf.cast(image_resized, tf.float32) / 255.0
+
+    # resize masks to (target_height, target_width) using nearest neighbor ===
+    # Vectorized resize over batch dimension; works even if N == 0.
+    masks_resized = tf.image.resize(
+        tf.expand_dims(tf.cast(masks, tf.float32), axis=-1),  # [N,H,W,1]
+        size=(target_height, target_width),
+        method="nearest"
+    )
+    masks_resized = tf.cast(tf.round(tf.squeeze(masks_resized, axis=-1)), tf.uint8)  # [N,new_h,new_w]
+
+    scales = tf.cast([scale_x, scale_y, scale_x, scale_y], dtype=tf.float32)
+    bboxes = bboxes * scales  # element-wise broadcast
+
+    def _generate_solo_targets_multi_scale(i, cate_acc, mask_acc):
+        # enumerate i-th grid/scale_range
+        grid_size_i = grid_sizes[i]
+        scale_range_i = scale_ranges[i]  # shape [2], e.g. (scale_min, scale_max)
+
+        # Compute single-scale targets
+        cate_target_i, mask_target_i = generate_solo_targets_single_scale(
+            cat_ids,
+            masks_resized,
+            bboxes,
+            target_height,
+            target_width,
+            grid_size_i,
+            scale_range_i,  # (scale_min, scale_max) for sqrt(area)
+            scale,  # feature-map scale factor (e.g., 1/4)
+            center_radius=0  # radius (grid cells) around center to assign
+        )
+
+        # Flatten category target from [grid_size, grid_size] -> [grid_size*grid_size]
+        cate_target_i = tf.reshape(cate_target_i, [-1])
+
+        new_cate_acc = tf.concat([cate_acc, cate_target_i], axis=0)
+        new_mask_acc = tf.concat([mask_acc, mask_target_i], axis=2)
+
+        return i + 1, new_cate_acc, new_mask_acc
+
+    # Number of scales
+    num_scales = tf.shape(grid_sizes)[0]
+
+    feat_h = tf.cast(tf.round(tf.cast(target_height, tf.float32) * scale), tf.int32)
+    feat_w = tf.cast(tf.round(tf.cast(target_width, tf.float32) * scale), tf.int32)
+
+    # Initialize accumulators
+    cate_init = tf.zeros([0], dtype=tf.int32)
+    mask_init = tf.zeros(
+        [tf.cast(feat_h, tf.int32),
+         tf.cast(feat_w, tf.int32),
+         0],
+        dtype=tf.uint8
+    )
+
+    # Loop
+    _, cate_targets, mask_targets = tf.while_loop(
+        cond=lambda i, *_: i < num_scales,
+        body=_generate_solo_targets_multi_scale,
+        loop_vars=[tf.constant(0), cate_init, mask_init],
+        shape_invariants=[
+            tf.TensorShape([]),  # i
+            tf.TensorShape([None]),  # cate_acc grows along axis 0
+            tf.TensorShape([None, None, None])  # mask_acc grows along axis 2
+        ]
+    )
+
+    return image_resized, cate_targets, mask_targets
+
+def create_coco_tfrecord_dataset(
+    train_tfrecord_directory: str,
+    target_size: Tuple[int, int],
+    batch_size: int,
+    grid_sizes,
+    scale: float = 2.5,
+    deterministic: bool = False,
+    augment: bool = True,
+    shuffle_buffer_size: Optional[int] = None,
+    number_images: Optional[int] = None
+) -> tf.data.Dataset:
+    """Creates a `tf.data.Dataset` from COCO TFRecord shards and emits SOLO targets.
+
+    This utility:
+      * Scans a directory for `*.tfrecord` shards.
+      * Builds a streaming `TFRecordDataset`.
+      * Optionally shuffles and/or limits the number of examples.
+      * Parses each example and constructs multi-scale SOLO targets via `parse_example`.
+      * Batches and prefetches the dataset.
+
+    Args:
+      train_tfrecord_directory: Path to directory containing TFRecord shards.
+      target_size: Tuple[int, int]. Target (height, width) for image & mask resizing.
+      batch_size: Batch size for the resulting dataset.
+      grid_sizes: Sequence of ints. SOLO grid sizes per scale (e.g., [40, 36, ...]).
+      scale: Float. Feature-map scale factor used in target generation (e.g., 2.5).
+        Note: This is later passed to `parse_example` which expects a downscale
+        factor (e.g., 0.25); ensure consistency with your pipeline.
+      deterministic: If False (default), allow non-deterministic map parallelism.
+      augment: If True (default), apply data augmentations in `parse_example`.
+      shuffle_buffer_size: Optional shuffle buffer size. If provided, shuffling is enabled.
+      number_images: Optional cap on the number of images to take from the stream.
+
+    Returns:
+      tf.data.Dataset: A dataset of batched tuples:
+        - image_resized: [B, Ht, Wt, 3] (float32) in [0, 1]
+        - cate_targets: [B, sum(S_i^2)] (int32)
+        - mask_targets: [B, Hf, Wf, sum(S_i^2)] (uint8)
+    """
+    scale_ranges = compute_scale_ranges(target_size[0], target_size[1], num_levels=len(grid_sizes))
+    scale_ranges = tf.stack(scale_ranges, axis=0)
+    scale_ranges = tf.cast(scale_ranges, tf.float32)
+
+    grid_sizes_tf = tf.cast(grid_sizes, tf.int32)
+
+    target_height, target_width = target_size
+    augment_tf = tf.constant(augment)
+
+    # Gather all shard paths (common suffixes)
+    pattern = "*.tfrecord"
+    files = tf.io.gfile.glob(os.path.join(train_tfrecord_directory, pattern))
+
+    if not files:
+        raise FileNotFoundError(f"No TFRecord files found in: {train_tfrecord_directory}")
+
+    ds = tf.data.TFRecordDataset(files, num_parallel_reads=len(files))
+
+    # Shuffle
+    if shuffle_buffer_size is not None:
+        ds = ds.shuffle(buffer_size=shuffle_buffer_size, reshuffle_each_iteration=True)
+
+    if number_images is not None:
+        ds = ds.take(number_images)
+
+    # Parse
+    ds = ds.map(lambda x: parse_example(x, target_height=target_height, target_width=target_width,
+                                        grid_sizes=grid_sizes_tf, scale=scale, scale_ranges=scale_ranges, augment=augment_tf),
+                num_parallel_calls=tf.data.AUTOTUNE, deterministic=deterministic)
+
+    ds = ds.batch(batch_size, drop_remainder=False)
+    ds = ds.prefetch(tf.data.AUTOTUNE)
+    return ds

--- a/config.py
+++ b/config.py
@@ -11,17 +11,17 @@ class DynamicSOLOConfig(object):
         self.train_annotation_path = f'{self.coco_root_path}/annotations/instances_train2017.json'
         self.classes_path = 'data/coco_classes.txt'
         self.images_path = f'{self.coco_root_path}/train2017/'
-        self.include_background=True    # Exclude background 0th class for custom COCO dataset
+        self.include_background=False    # Exclude background 0th class for custom COCO dataset
         self.number_images=None  # Restriction for dataset. Set None to get rid of the restriction
 
         # Image parameters
-        self.img_height = 320
-        self.img_width = 320
+        self.img_height = 480
+        self.img_width = 480
 
         # If load_previous_model = True: load the previous model weights (example: './weights/coco_epoch00001000.keras')
         self.load_previous_model = False
-        self.lr = 0.0001
-        self.batch_size = 8
+        self.lr = 0.001
+        self.batch_size = 32
         # If load_previous_model = True, you need to specify self.model_path to indicate which model to read the weights from to continue training.
         self.model_path = './weights/coco_epoch00000001.keras'
 
@@ -34,7 +34,17 @@ class DynamicSOLOConfig(object):
 
         self.grid_sizes = [40, 36, 24, 16]
         self.image_scales = [0.25]
+        self.augment = True
 
         # Testing configuration
         self.test_model_path = './weights/coco_epoch00000001.keras'
         self.score_threshold = 0.5
+
+        # Accumulation mode
+        self.use_gradient_accumulation_steps = False
+        self.accumulation_steps = 2
+
+        # Dataset options
+        self.use_optimized_dataset = False  # Use TFRecord dataset for training if True
+        self.tfrecord_dataset_directory_path = f'{self.coco_root_path}/tfrecords/train'  # Path to TFRecord dataset directory
+        self.shuffle_buffer_size = 2048  # TFRecord dataset shuffle buffer size. Set to None to disable shuffling

--- a/convert_coco_to_tfrecord.py
+++ b/convert_coco_to_tfrecord.py
@@ -1,0 +1,454 @@
+"""
+Author: Pavel Timonin
+Created: 2025-10-17
+Description: This script converts a COCO-format dataset (images + annotations) into TFRecord(s).
+
+- Skips images whose files do not exist.
+- Skips annotations that don't produce a valid mask.
+- Writes instance masks to TFRecord as PNG-compressed bytes (one per object).
+
+Example
+-------
+python convert_coco_to_tfrecord.py \
+  --images_root /path/to/images \
+  --annotations /path/to/instances_train.json \
+  --output /path/to/out/train.tfrecord \
+  --num_shards 4
+
+Notes
+-----
+- BBoxes are stored in absolute pixel coordinates (xmin, ymin, xmax, ymax).
+- Category IDs are stored as-is from the COCO file.
+- Masks are stored as a bytes_list feature named "image/object/mask_png"; each element is a PNG for an instance binary mask.
+"""
+
+from __future__ import annotations
+
+import argparse
+import io
+import json
+from pathlib import Path
+from typing import List, Tuple
+from coco_dataset import ann_to_mask
+import numpy as np
+from PIL import Image
+
+from pycocotools.coco import COCO
+
+import tensorflow as tf
+
+
+def _bytes_feature(value: bytes) -> tf.train.Feature:
+    """
+    Builds a `tf.train.Feature` containing a single bytes value.
+
+    Args:
+        value (bytes): The raw bytes to store.
+
+    Returns:
+        tf.train.Feature: A feature with `bytes_list` set to `[value]`.
+    """
+    return tf.train.Feature(bytes_list=tf.train.BytesList(value=[value]))
+
+def _bytes_list_feature(values: List[bytes]) -> tf.train.Feature:
+    """
+    Builds a `tf.train.Feature` containing a list of bytes values.
+
+    Args:
+        values (List[bytes]): Iterable of byte strings to store.
+
+    Returns:
+        tf.train.Feature: A feature with `bytes_list` set to `values`.
+    """
+    return tf.train.Feature(bytes_list=tf.train.BytesList(value=list(values)))
+
+
+def _int64_feature(value: int) -> tf.train.Feature:
+    """
+    Builds a `tf.train.Feature` containing a single int64 value.
+
+    Args:
+        value (int): The integer to store.
+
+    Returns:
+        tf.train.Feature: A feature with `int64_list` set to `[value]`.
+    """
+    return tf.train.Feature(int64_list=tf.train.Int64List(value=[value]))
+
+
+def _int64_list_feature(values: List[int]) -> tf.train.Feature:
+    """
+    Builds a `tf.train.Feature` containing a list of int64 values.
+
+    Args:
+        values (List[int]): Iterable of integers to store.
+
+    Returns:
+        tf.train.Feature: A feature with `int64_list` set to `values`.
+    """
+    return tf.train.Feature(int64_list=tf.train.Int64List(value=list(values)))
+
+
+def _float_list_feature(values: List[float]) -> tf.train.Feature:
+    """
+    Builds a `tf.train.Feature` containing a list of float values.
+
+    Args:
+        values (List[float]): Iterable of floats to store.
+
+    Returns:
+        tf.train.Feature: A feature with `float_list` set to `values`.
+    """
+    return tf.train.Feature(float_list=tf.train.FloatList(value=list(values)))
+
+
+def encode_mask_png(mask: np.ndarray) -> bytes:
+    """
+    Encodes a single-channel binary mask as PNG bytes.
+
+    If `mask` is not `uint8`, it is cast. Masks with values in {0, 1}
+    are scaled to {0, 255} for readability when decoded later.
+
+    Args:
+        mask (np.ndarray): 2D array representing the mask. Expected values are
+            {0, 1} or {0, 255}. Other dtypes are cast to `np.uint8`.
+
+    Returns:
+        bytes: PNG-encoded bytes of the mask image.
+    """
+    if mask.dtype != np.uint8:
+        mask = mask.astype(np.uint8)
+    # Store as 0 or 255 for better readability if decoded later
+    if mask.max() <= 1:
+        mask = mask * 255
+    img = Image.fromarray(mask, mode="L")
+    buf = io.BytesIO()
+    img.save(buf, format="PNG", optimize=True)
+    return buf.getvalue()
+
+
+def coco_bbox_to_xyxy(bbox_xywh: List[float]) -> Tuple[float, float, float, float]:
+    """
+    Converts a COCO-format box [x, y, w, h] to [xmin, ymin, xmax, ymax].
+
+    Args:
+        bbox_xywh (List[float]): Bounding box in COCO format (top-left x/y, width, height).
+
+    Returns:
+        Tuple[float, float, float, float]: `(xmin, ymin, xmax, ymax)` as floats.
+    """
+    x, y, w, h = bbox_xywh
+    return float(x), float(y), float(x + w), float(y + h)
+
+
+def load_image_bytes_and_size(path: Path) -> Tuple[bytes, int, int, str]:
+    """
+    Reads an image file as bytes and returns its size and format.
+
+    Uses PIL to determine width/height/format without decoding twice.
+
+    Args:
+        path (Path): Path to the image file.
+
+    Returns:
+        Tuple[bytes, int, int, str]: A tuple `(data, height, width, fmt)` where:
+            - `data` (bytes): Raw file bytes.
+            - `height` (int): Image height in pixels.
+            - `width` (int): Image width in pixels.
+            - `fmt` (str): Lowercased image format (e.g., `"jpeg"`, `"png"`), or
+              empty string if unknown.
+    """
+    with open(path, "rb") as f:
+        data = f.read()
+    # Use PIL to get size without decoding twice
+    with Image.open(io.BytesIO(data)) as img:
+        width, height = img.size
+        fmt = (img.format or "").lower()
+    return data, height, width, fmt
+
+
+def open_sharded_writers(output_pattern: str, num_shards: int):
+    """
+    Creates TFRecord writers for (optionally) sharded output.
+
+    If `num_shards == 1`, a single writer is created for `output_pattern`.
+    If `num_shards > 1` and `"{shard}"` is not in `output_pattern`, a suffix
+    `-{shard:05d}-of-{num_shards:05d}` plus the file suffix is appended.
+
+    Args:
+        output_pattern (str): Output path or pattern. May include `"{shard}"`.
+        num_shards (int): Number of shards to create (>= 1).
+
+    Returns:
+        Tuple[List[tf.io.TFRecordWriter], Callable[[int], int]]:
+            - List of writers (length == `num_shards`).
+            - A formatter function mapping an item index to a writer index (0..num_shards-1).
+    """
+    if num_shards < 1:
+        raise ValueError("num_shards must be >= 1")
+
+    # If no shard placeholder present and num_shards>1, append one.
+    if num_shards == 1:
+        writers = [tf.io.TFRecordWriter(output_pattern)]
+        return writers, (lambda _: 0)
+
+    if "{shard}" not in output_pattern:
+        base = Path(output_pattern)
+        stem = base.stem
+        suffix = base.suffix or ".tfrecord"
+        output_pattern = str(base.with_name(f"{stem}-{{shard:05d}}-of-{num_shards:05d}{suffix}"))
+
+    writers = [tf.io.TFRecordWriter(output_pattern.format(shard=i)) for i in range(num_shards)]
+    return writers, (lambda idx: idx % num_shards)
+
+
+def build_example(
+    img_bytes: bytes,
+    height: int,
+    width: int,
+    filename: str,
+    image_id: int,
+    img_fmt: str,
+    anns: List[dict],
+) -> tf.train.Example:
+    """
+    Builds a `tf.train.Example` for an image and its instance annotations.
+
+    The example includes encoded image bytes and per-instance fields such as
+    bounding boxes, areas, category IDs, iscrowd flags, and PNG-encoded masks.
+
+    Args:
+        img_bytes (bytes): Raw encoded image bytes.
+        height (int): Image height in pixels.
+        width (int): Image width in pixels.
+        filename (str): Basename of the image file.
+        image_id (int): Unique image identifier (e.g., COCO image id).
+        img_fmt (str): Lowercased image format (e.g., `"jpeg"`, `"png"`), may be empty.
+        anns (List[dict]): COCO-style annotations for the image. Each annotation must
+            contain at least `bbox`, `category_id`, and a valid `segmentation`.
+
+    Returns:
+        tf.train.Example: A serialized example containing image-level and object-level features.
+
+    Raises:
+        KeyError: If required annotation keys are missing.
+        ValueError: If any annotation cannot be converted to a mask.
+    """
+    # Prepare per-object fields
+    xmins: List[float] = []
+    ymins: List[float] = []
+    xmaxs: List[float] = []
+    ymaxs: List[float] = []
+    areas: List[float] = []
+    cat_ids: List[int] = []
+    iscrowds: List[int] = []
+    mask_pngs: List[bytes] = []
+
+    for ann in anns:
+        # bbox
+        xmin, ymin, xmax, ymax = coco_bbox_to_xyxy(ann["bbox"])  # COCO bbox: [x,y,w,h]
+        xmins.append(xmin)
+        ymins.append(ymin)
+        xmaxs.append(xmax)
+        ymaxs.append(ymax)
+        areas.append(float(ann.get("area", (xmax - xmin) * (ymax - ymin))))
+        cat_ids.append(int(ann["category_id"]))
+        iscrowds.append(int(ann.get("iscrowd", 0)))
+
+        # mask -> PNG bytes
+        mask = ann_to_mask(ann, height, width)
+        mask_pngs.append(encode_mask_png(mask))
+
+    example = tf.train.Example(
+        features=tf.train.Features(
+            feature={
+                "image/encoded": _bytes_feature(img_bytes),
+                "image/height": _int64_feature(int(height)),
+                "image/width": _int64_feature(int(width)),
+                "image/filename": _bytes_feature(filename.encode("utf-8")),
+                "image/id": _int64_feature(int(image_id)),
+                "image/format": _bytes_feature((img_fmt or "").encode("utf-8")),
+                # Object fields
+                "image/object/bbox/xmin": _float_list_feature(xmins),
+                "image/object/bbox/ymin": _float_list_feature(ymins),
+                "image/object/bbox/xmax": _float_list_feature(xmaxs),
+                "image/object/bbox/ymax": _float_list_feature(ymaxs),
+                "image/object/area": _float_list_feature(areas),
+                "image/object/category_id": _int64_list_feature(cat_ids),
+                "image/object/iscrowd": _int64_list_feature(iscrowds),
+                "image/object/mask_png": _bytes_list_feature(mask_pngs),
+            }
+        )
+    )
+    return example
+
+
+def convert(
+    images_root: Path,
+    annotations_json: Path,
+    output_pattern: str,
+    num_shards: int = 1,
+    allow_empty_masks: bool = False,
+) -> None:
+    """
+    Converts COCO annotations + images into TFRecord(s) with masks.
+
+    Iterates over images listed in `annotations_json`, filters annotations to those
+    with decodable (optionally non-empty) masks, builds `tf.train.Example`s, and writes
+    them to one or more TFRecord shards.
+
+    Args:
+        images_root (Path): Directory containing the image files referenced by COCO.
+        annotations_json (Path): Path to the COCO annotations JSON file.
+        output_pattern (str): Output TFRecord path or pattern. If `num_shards > 1`,
+            include `"{shard}"` or a `-{shard}-of-N` suffix will be appended automatically.
+        num_shards (int, optional): Number of shards to write. Defaults to `1`.
+        allow_empty_masks (bool, optional): If `True`, keep annotations whose decoded mask
+            is empty. If `False`, empty masks are dropped. Defaults to `False`.
+
+    Returns:
+        None
+
+    Logs:
+        Prints periodic progress and a final JSON summary of totals and skips.
+    """
+    coco = COCO(str(annotations_json))
+
+    img_ids = sorted(coco.getImgIds())
+    images = coco.loadImgs(img_ids)
+
+    skipped_missing = 0
+    skipped_no_valid_anns = 0
+    total = 0
+    written = 0
+
+    writers, shard_of = open_sharded_writers(output_pattern, num_shards)
+
+    try:
+        for idx, img in enumerate(images):
+            total += 1
+            file_name = img["file_name"]
+            img_path = images_root / file_name
+            if not img_path.exists():
+                skipped_missing += 1
+                continue
+
+            try:
+                img_bytes, h, w, fmt = load_image_bytes_and_size(img_path)
+            except Exception:
+                skipped_missing += 1
+                continue
+
+            ann_ids = coco.getAnnIds(imgIds=[img["id"]], iscrowd=None)
+            anns = coco.loadAnns(ann_ids)
+
+            # Filter to annotations that have a usable segmentation/mask
+            valid_anns = []
+            for ann in anns:
+                segm = ann.get("segmentation", None)
+                if segm is None:
+                    continue
+                if isinstance(segm, list) and len(segm) == 0:
+                    continue
+                if isinstance(segm, dict) and (not segm.get("counts")):
+                    continue
+                try:
+                    mask = ann_to_mask(ann, h, w)
+                except Exception:
+                    continue
+                if mask is None:
+                    continue
+                if not allow_empty_masks and mask.sum() == 0:
+                    continue
+                valid_anns.append(ann)
+
+            if len(valid_anns) == 0:
+                skipped_no_valid_anns += 1
+                continue
+
+            example = build_example(
+                img_bytes=img_bytes,
+                height=h,
+                width=w,
+                filename=file_name,
+                image_id=int(img["id"]),
+                img_fmt=fmt,
+                anns=valid_anns,
+            )
+
+            shard_id = shard_of(idx)
+            writers[shard_id].write(example.SerializeToString())
+            written += 1
+
+            if written % 500 == 0:
+                print(f"progress: written={written} / seen={total}")
+    finally:
+        for w in writers:
+            w.close()
+
+    print(
+        json.dumps(
+            {
+                "total_images": total,
+                "written": written,
+                "skipped_missing_files": skipped_missing,
+                "skipped_no_valid_annotations": skipped_no_valid_anns,
+                "output_pattern": output_pattern,
+                "num_shards": num_shards,
+            },
+            indent=2,
+        ),
+        json.dumps(
+        {
+
+                "skipped_missing_files": skipped_missing,
+                "skipped_no_valid_annotations": skipped_no_valid_anns,
+                "output_pattern": output_pattern,
+                "num_shards": num_shards,
+            },
+            indent=2,
+        )
+    )
+
+
+def parse_args() -> argparse.Namespace:
+    """
+    Parses command-line arguments for the COCO → TFRecord converter.
+
+    Returns:
+        argparse.Namespace: Parsed arguments with fields:
+            - `images_root` (Path): Directory containing images.
+            - `annotations` (Path): Path to COCO annotations JSON.
+            - `output` (str): Output TFRecord path or sharded pattern.
+            - `num_shards` (int): Number of shards to write.
+            - `allow_empty_masks` (bool): Keep empty masks if set.
+    """
+    p = argparse.ArgumentParser(description="COCO -> TFRecord converter with masks")
+    p.add_argument("--images_root", type=Path, required=True, help="Directory where images are stored")
+    p.add_argument("--annotations", type=Path, required=True, help="Path to COCO annotations JSON")
+    p.add_argument(
+        "--output",
+        type=str,
+        required=True,
+        help=(
+            "Output TFRecord path. If --num_shards>1, include '{shard}' placeholder or a '-{shard}-of-N' suffix will be appended."
+        ),
+    )
+    p.add_argument("--num_shards", type=int, default=1, help="Number of shards to write")
+    p.add_argument(
+        "--allow_empty_masks",
+        action="store_true",
+        help="If set, keep anns whose decoded mask is empty (default: drop)",
+    )
+    return p.parse_args()
+
+
+if __name__ == "__main__":
+    args = parse_args()
+    convert(
+        images_root=args.images_root,
+        annotations_json=args.annotations,
+        output_pattern=args.output,
+        num_shards=args.num_shards,
+        allow_empty_masks=args.allow_empty_masks,
+    )

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 tensorflow
 opencv-python
 pycocotools
+pillow

--- a/test.py
+++ b/test.py
@@ -15,6 +15,7 @@ from pycocotools.coco import COCO
 
 from config import DynamicSOLOConfig
 from coco_dataset import get_classes
+from model_functions import SOLOModel
 import logging
 
 FORMAT = '%(asctime)s-%(levelname)s: %(message)s'
@@ -24,22 +25,27 @@ logger = logging.getLogger(__name__)
 
 def preprocess_image(image_path, input_size=(320, 320)):
     """
-    Loads an image from disk, resizes it to a fixed input size, and normalizes pixel values to [0, 1].
+    Load an image, resize to a fixed size, and normalize pixel values to [0, 1].
 
-    The function also returns the original image shape and the unnormalized RGB image
+    Also returns the original image shape and the unnormalized RGB image.
 
     Args:
-        image_path (str): Path to the input image file.
-        input_size (Tuple[int, int], optional): Target size (width, height) to resize the image to. Defaults to (320, 320).
+      image_path (str): Path to the input image file.
+      input_size (Tuple[int, int], optional): Target size `(width, height)` to
+        resize the image to. Defaults to `(320, 320)`.
 
     Returns:
-        Tuple[np.ndarray, Tuple[int, int], np.ndarray]:
-            - img_resized (np.ndarray): The resized and normalized image of shape (H, W, 3), dtype float32.
-            - original_shape (Tuple[int, int]): The original image shape as (height, width).
-            - img (np.ndarray): The original RGB image before resizing and normalization.
+      Tuple[np.ndarray, Tuple[int, int], np.ndarray]:
+        A 3-tuple `(img_resized, original_shape, img)` where:
+          * `img_resized` (np.ndarray): Resized and normalized RGB image of
+            shape `(H, W, 3)`, dtype `float32`, values in `[0, 1]`.
+          * `original_shape` (Tuple[int, int]): Original image height and width
+            as `(H_orig, W_orig)`.
+          * `img` (np.ndarray): Original RGB image **before** resizing and
+            normalization, dtype `uint8`, values in `[0, 255]`.
 
     Raises:
-        ValueError: If the image cannot be read from the given path.
+      ValueError: If the image cannot be read from `image_path`.
     """
     img = cv2.imread(image_path, cv2.IMREAD_COLOR)
     if img is None:
@@ -54,21 +60,32 @@ def preprocess_image(image_path, input_size=(320, 320)):
     return img_resized, original_shape, img
 
 @tf.function
-def matrix_nms(masks, scores, labels, pre_nms_k=500, post_nms_k=100, score_threshold=0.05, sigma=0.5):
+def matrix_nms(masks, scores, labels, pre_nms_k=500, post_nms_k=100, score_threshold=0.5, sigma=0.5):
     """
-    Perform class-wise Matrix NMS on instance masks.
+    Perform Matrix NMS for class-aware suppression of instance masks.
 
-    Parameters:
-        masks (tf.Tensor): Tensor of shape (N, H, W) with each mask as a sigmoid probability map (0~1).
-        scores (tf.Tensor): Tensor of shape (N,) with confidence scores for each mask.
-        labels (tf.Tensor): Tensor of shape (N,) with class labels for each mask (ints).
-        pre_nms_k (int): Number of top-scoring masks to keep before applying NMS.
-        post_nms_k (int): Number of final masks to keep after NMS.
-        score_threshold (float): Score threshold to filter out masks after NMS (default 0.5).
-        sigma (float): Sigma value for Gaussian decay.
+    This implementation follows the Matrix NMS formulation where each candidate’s
+    score is decayed by the maximum IoU it has with higher-scoring, same-class
+    candidates. Masks are first binarized at 0.5.
+
+    Args:
+      masks (tf.Tensor): Predicted masks of shape `(N, H, W)`, values in `[0, 1]`.
+      scores (tf.Tensor): Confidence scores of shape `(N,)`.
+      labels (tf.Tensor): Class indices of shape `(N,)`, dtype integer.
+      pre_nms_k (Optional[int]): If provided, keep only the top-`k` by `scores`
+        before NMS to reduce computation. Defaults to `500`.
+      post_nms_k (Optional[int]): If provided, keep only the top-`k` by decayed
+        scores after NMS. If `None`, keep all above the threshold. Defaults to `100`.
+      score_threshold (float): Minimum decayed score to keep a mask. Defaults to `0.5`.
+      sigma (float): Gaussian decay parameter used in Matrix NMS. Defaults to `0.5`.
 
     Returns:
-        tf.Tensor: Tensor of indices of masks kept after suppression.
+      tf.Tensor: Indices (into the original `masks/scores/labels` tensors) of the
+      kept detections after Matrix NMS, shape `(M,)`, dtype `int32`.
+
+    Notes:
+      * IoU is computed on binarized masks (`>= 0.5`).
+      * Suppression is class-aware; cross-class pairs do not contribute to decay.
     """
     # Binarize masks at 0.5 threshold
     seg_masks = tf.cast(masks >= 0.5, dtype=tf.float32)  # shape: (N, H, W)
@@ -134,56 +151,35 @@ def matrix_nms(masks, scores, labels, pre_nms_k=500, post_nms_k=100, score_thres
     kept_indices = tf.gather(topk_indices, final_indices)
     return kept_indices
 
-
-def postprocess_solo_outputs(
-    cate_preds,          # list[Tensor], each (1, S_l, S_l, C) => per-class logits
-    mask_preds,          # list[Tensor], each (1, H_l, W_l, S_l^2)
-    mask_feat,          # Tensor [1, H_l, W_l, E]
-    resized_image_shape, # (resized_h, resized_w)
-    score_threshold=0.5,
-    from_logits=True,       # We'll interpret it as "model returns logits => apply sigmoid"
-    nms_method='gaussian',
-    include_background=False,
-    nms_sigma=0.5
-):
+@tf.function
+def get_instances(resized_h, resized_w, cate_preds, mask_preds, mask_feat, score_threshold):
     """
-    Post-processes SOLO network outputs to generate instance masks and class predictions.
+    Convert SOLO head outputs into per-instance masks/scores/classes.
 
-    This function takes multi-scale classification and mask outputs from the SOLO model,
-    applies thresholding, selects candidate masks, and performs matrix NMS (Non-Maximum Suppression)
-    to filter and refine the final instances.
+    This function gathers all grid-cell/class pairs whose classification
+    probability exceeds `score_threshold`, upsamples their corresponding mask
+    logits to the given resized image shape, and returns tensors suitable for
+    downstream NMS.
 
     Args:
-        cate_preds (List[Tensor]): List of category score tensors, each of shape (1, S_l, S_l, C),
-            where S_l is the grid size at level l, and C is the number of classes.
-        mask_preds (List[Tensor]): List of mask prediction tensors, each of shape (1, H_l, W_l, S_l),
-            where H_l and W_l are the spatial dimensions of the feature maps.
-        mask_feat (Tensor): Mask feature tensor of shape (1, H_l, W_l, E), where E is the feature dimension.
-        resized_image_shape (Tuple[int, int]): Target shape (height, width) of the output masks.
-        score_threshold (float, optional): Minimum confidence threshold to retain a (cell, class) prediction. Defaults to 0.5.
-        from_logits (bool, optional): Whether the `cate_preds` are logits (if True, sigmoid will be applied). Defaults to True.
-        nms_method (str, optional): NMS method to use ("gaussian" or "linear"). Defaults to "gaussian".
-        include_background (bool, optional): Whether to include background class predictions. Defaults to False.
-        nms_sigma (float, optional): Sigma value for Gaussian NMS method. Defaults to 0.5.
+        resized_h (int): Height of the resized/reference image for masks.
+        resized_w (int): Width of the resized/reference image for masks.
+        cate_preds (tf.Tensor): Category logits of shape `[1, sum(S_i*S_i), C]` where `C` includes background at index 0.
+        mask_preds (tf.Tensor): Mask kernels of shape `[1, H_l, W_l, sum(S_i*S_i)]`.
+        mask_feat (tf.Tensor): Mask features of shape `[1, H_l, W_l, E]`.
+        score_threshold (float): Minimum class probability to keep a (cell, class) candidate.
 
     Returns:
-        List[dict]: A list of instances, each a dictionary containing:
-            - "class_id" (int): Predicted class ID.
-            - "score" (float): Confidence score after NMS.
-            - "mask" (np.ndarray): Binary mask (shape: resized_h x resized_w) with values in {0, 1}.
+        Tuple[tf.Tensor, tf.Tensor, tf.Tensor]:
+        `(selected_masks, selected_scores, selected_classes)` where
+            * `selected_masks` has shape `(K, resized_h, resized_w)` with values in `[0, 1]` (after sigmoid + bilinear upsampling).
+            * `selected_scores` has shape `(K,)` with per-instance class probabilities (after softmax over classes, background removed).
+            * `selected_classes` has shape `(K,)` with zero-based foreground class indices (i.e., background class 0 is excluded).
 
     Notes:
-        - Soft masks are generated before binarization after NMS.
-        - Multiple predictions can initially originate from the same grid cell.
-        - Matrix NMS is used for better handling of overlapping masks compared to standard NMS.
+        * If no candidate passes the threshold, returns three empty tensors.
+        * This function assumes background occupies class index `0` in `cate_preds` and removes it for thresholding.
     """
-    resized_h, resized_w = resized_image_shape
-
-    # Gather all candidates
-    all_scores = []
-    all_classes = []
-    all_masks_resized = []
-
     # batch size
     B = tf.shape(mask_feat)[0]
     # featuremap spatial dims
@@ -191,80 +187,102 @@ def postprocess_solo_outputs(
     # number of kernels
     E = tf.shape(mask_feat)[3]
 
+    cate_out = cate_preds[0]  # => shape [sum(S_i*S_i), num_classes]
+
     # Flatten mask_feat spatially: [B, H*W, E]
     mask_feat_flat = tf.reshape(mask_feat, [B, H * W, E])
+    mask_out = tf.linalg.matmul(mask_feat_flat, mask_preds, transpose_b=True)
+    mask_out = tf.reshape(mask_out, (B, H, W, tf.shape(mask_out)[2]))
 
-    # Loop over FPN levels
-    for cate_out, mask_kernel in zip(cate_preds, mask_preds):
-        # Remove batch dim => (S_l, S_l, C) & (H_l, W_l, S_l^2)
-        cate_out = cate_out[0]  # => shape (S_l, S_l, C)
+    mask_out = mask_out[0]  # => shape (H_l, W_l, S_l^2)
 
-        # Flatten mask_kernel_pred over the grid to get [B, S^2, E]
-        mask_kernel_flat = tf.reshape(mask_kernel, [B, -1, E])
-        # Dynamic conv: dot each kernel with every spatial feature
-        #    mask_pred: [B, H*W, N]
-        mask_out = tf.linalg.matmul(mask_feat_flat, mask_kernel_flat, transpose_b=True)
-        mask_out = tf.reshape(mask_out, (B, H, W, tf.shape(mask_out)[2]))
+    # Convert category logits => per-class probabilities (sigmoid)
+    cate_prob = tf.nn.softmax(cate_out, axis=-1) # shape [sum(S_i*S_i), num_classes]
+
+    # Convert mask logits => [0,1]
+    mask_prob = tf.sigmoid(mask_out)  # shape (H_l, W_l, S_l^2)
+
+    # Get rid of the background. Assume background has 0th index
+    cate_prob = cate_prob[..., 1:]
+
+    # Threshold in one shot (multi-label)
+    # mask_bool[i, j] = True if cate_prob[i, j] >= threshold
+    mask_bool = cate_prob >= tf.cast(score_threshold, tf.float32)  # shape (S_l*S_l, C)
+
+    # Get indices of (cell, class) pairs and their scores
+    idx = tf.where(mask_bool)
+
+    # Early exit if nothing passes the threshold
+    def _empty():
+        return (tf.zeros([0, resized_h, resized_w], tf.float32),
+                tf.zeros([0], tf.float32),
+                tf.zeros([0], tf.int32))
+
+    def _non_empty():
+        selected_scores = tf.gather_nd(cate_prob, idx)  # [K]
+        selected_classes = tf.cast(idx[:, 1], tf.int32)  # [K]
+        selected_cells = tf.cast(idx[:, 0], tf.int32)  # [K]
+
+        # Resize all S mask channels once (vectorized), then gather
+        # mask_prob: [H_l, W_l, S] -> [K, H_l, W_l, 1] for tf.image.resize
+        masks = tf.gather(mask_prob, selected_cells, axis=-1)  # [H_l, W_l, K]
+        masks = tf.transpose(masks, [2, 0, 1])  # [K, H_l, W_l]
+        masks = masks[..., tf.newaxis]  # [K, H_l, W_l, 1]
+
+        # Bilinear resize with antialiasing (keeps values soft in [0,1])
+        masks_up = tf.image.resize(
+            masks, [resized_h, resized_w],
+            method='bilinear', antialias=True
+        )  # [K, H', W', 1]
+        selected_masks = tf.squeeze(masks_up, axis=-1)  # [K, H', W']
+
+        return selected_masks, selected_scores, selected_classes
+
+    return tf.cond(tf.shape(idx)[0] > 0, _non_empty, _empty)
 
 
-        mask_out = mask_out[0]  # => shape (H_l, W_l, S_l^2)
-        S_l = cate_out.shape[0]
+def postprocess_solo_outputs(
+    cate_preds,          # Tensor of shape [1, sum(S_i*S_i), C]
+    mask_preds,          # Tensor of shape [1, H_l, W_l, sum(S_i*S_i)]
+    mask_feat,          # Tensor [1, H_l, W_l, E]
+    resized_image_shape, # (resized_h, resized_w)
+    score_threshold=0.5,
+    nms_sigma=0.5
+):
+    """
+    Convert raw SOLO outputs into final instance predictions.
 
-        # Convert category logits => per-class probabilities (sigmoid)
-        if from_logits:
-            cate_prob = tf.sigmoid(cate_out).numpy()  # shape (S_l, S_l, C)
-        else:
-            cate_prob = cate_out.numpy()  # already in [0,1]
+    Runs candidate extraction (`get_instances`), applies Matrix NMS, and
+    returns a sorted list of instance dictionaries compatible with downstream
+    visualization or evaluation.
 
-        # Convert mask logits => [0,1]
-        if from_logits:
-            mask_prob = tf.sigmoid(mask_out).numpy()  # shape (H_l, W_l, S_l^2)
-        else:
-            mask_prob = mask_out.numpy()
+    Args:
+        cate_preds (tf.Tensor): Category logits of shape `[1, sum(S_i*S_i), C]`.
+        mask_preds (tf.Tensor): Mask kernels of shape `[1, H_l, W_l, sum(S_i*S_i)]`.
+        mask_feat (tf.Tensor): Mask features of shape `[1, H_l, W_l, E]`.
+        resized_image_shape (Tuple[int, int]): `(resized_h, resized_w)` used for upsampling masks.
+        score_threshold (float, optional): Classification probability threshold for candidate selection. Defaults to `0.5`.
+        nms_sigma (float, optional): Sigma parameter for Matrix NMS decay. Defaults to `0.5`.
 
-        if not include_background:
-            # Get rid of the background. Assume background has 0th index
-            cate_prob = cate_prob[..., 1:]
+    Returns:
+        List[dict]: A list of instances. Each item has keys:
+            * `"class_id"` (int): Zero-based class index (without background).
+            * `"score"` (float): Final post-NMS score.
+            * `"mask"` (np.ndarray): Binary mask of shape
+            `(resized_h, resized_w)`, `dtype=uint8` with values in `{0,1}`.
+        The list is sorted by descending `score`.
 
-        # For each cell (gy, gx), find all classes above score_threshold
-        for gy in range(S_l):
-            for gx in range(S_l):
-                class_probs = cate_prob[gy, gx, :]  # shape (C,)
-                # Multi-label approach => find all classes with prob >= threshold
-                above_thresh_indices = np.where(class_probs >= score_threshold)[0]
-                if len(above_thresh_indices) == 0:
-                    continue
+    Notes:
+        * If no candidates remain after thresholding/NMS, an empty list is returned.
+        * Returned masks are binarized at `0.5` after sigmoid.
+    """
+    resized_h, resized_w = resized_image_shape
 
-                # For each class that passes the threshold
-                for cls_id in above_thresh_indices:
-                    sc = class_probs[cls_id]
-                    chan_idx = gy * S_l + gx
-                    # Retrieve mask channel => shape (H_l, W_l)
-                    small_mask = mask_prob[..., chan_idx].astype(np.float32)
-
-                    # Upsample to (resized_h, resized_w)
-                    up_mask = cv2.resize(
-                        small_mask,
-                        (resized_w, resized_h),
-                        interpolation=cv2.INTER_LINEAR
-                    )
-                    # Keep it soft in [0,1]
-                    all_masks_resized.append(up_mask)
-                    all_scores.append(sc)
-                    all_classes.append(cls_id)
+    all_masks_arr_tf, all_scores_arr_tf, all_classes_arr_tf = get_instances(resized_h, resized_w, cate_preds, mask_preds, mask_feat, score_threshold)
 
     # If no candidates, return empty
-    if len(all_scores) == 0:
+    if all_masks_arr_tf.shape[0] == 0:
         return []
-
-    # Convert to arrays for Matrix NMS
-    all_scores_arr = np.array(all_scores, dtype=np.float32)     # (N,)
-    all_classes_arr = np.array(all_classes, dtype=np.int32)     # (N,)
-    all_masks_arr = np.stack(all_masks_resized, axis=0)         # (N, resized_h, resized_w)
-
-    all_scores_arr_tf = tf.convert_to_tensor(all_scores_arr)
-    all_classes_arr_tf = tf.convert_to_tensor(all_classes_arr)
-    all_masks_arr_tf = tf.convert_to_tensor(all_masks_arr)
 
     # Matrix NMS
     kept_indices = matrix_nms(
@@ -276,9 +294,9 @@ def postprocess_solo_outputs(
         sigma=nms_sigma
     )
 
-    final_masks = all_masks_arr[kept_indices.numpy()]
-    final_scores = all_scores_arr[kept_indices.numpy()]
-    final_classes = all_classes_arr[kept_indices.numpy()]
+    final_masks = tf.gather(all_masks_arr_tf, kept_indices, axis=0).numpy()
+    final_scores = tf.gather(all_scores_arr_tf, kept_indices, axis=0).numpy()
+    final_classes = tf.gather(all_classes_arr_tf, kept_indices, axis=0).numpy()
     final_masks = (final_masks > 0.5).astype(np.uint8)
 
     # Build the final instance list
@@ -303,18 +321,23 @@ def draw_solo_masks(
     class_names=None
 ):
     """
-    Overlays instance masks that are sized for 'resized_shape'
-    onto 'original_image' which is bigger (orig_h, orig_w).
+    Overlay instance masks and optional labels on an image.
+
+    Applies semi-transparent color overlays for each instance mask and, if
+    requested, draws a class label near the first pixel of the mask.
 
     Args:
-        original_image (np.ndarray): shape (orig_h, orig_w, 3)
-        instances (list of dict): each with {"class_id", "score", "mask"}
-            where 'mask' is shape (resized_h, resized_w) in {0,1}
-        show_labels (bool): show the labels of the instances if the flag set to True. Default True
-        class_names: optional
+        original_image (np.ndarray): Input image on which to draw. Typically **BGR** (OpenCV convention), `dtype=uint8`, shape `(H, W, 3)`.
+        instances (List[dict]): List of instance dicts as returned by `postprocess_solo_outputs` with keys `class_id`, `score`, and `mask` (binary `(h, w)` array).
+        show_labels (bool, optional): Whether to render text labels. Defaults to `True`.
+        class_names (Mapping[int, str] | Sequence[str] | None, optional): Mapping from class id to readable name. If provided and indexable by `class_id`, the corresponding name is used for the label.
 
     Returns:
-        vis_image: same shape as original_image, with masks overlaid
+        np.ndarray: Annotated image (same shape and dtype as `original_image`).
+
+    Notes:
+        * Overlay color is randomly sampled for each instance.
+        * If `class_names` is missing a key, a fallback `"ID=<id>, <score>"` label is used.
     """
     vis_image = original_image.copy()
     orig_h, orig_w = vis_image.shape[:2]
@@ -342,7 +365,7 @@ def draw_solo_masks(
             y0, x0 = ys[0], xs[0]
             score_str = f"{inst['score']:.2f}"
             if class_names and (0 <= inst['class_id'] < len(class_names)):
-                label_str = f"{class_names.get(inst['class_id'])}: {score_str}"
+                label_str = f"{class_names.get(inst['class_id'])}"#: {score_str}"
             else:
                 label_str = f"ID={inst['class_id']}, {score_str}"
             cv2.putText(
@@ -374,7 +397,20 @@ if __name__ == '__main__':
     # Create dictionary: {category_id: category_name}
     coco_classes = {cat['id']: cat['name'] for cat in categories}
 
-    solo = keras.models.load_model(model_path)
+    # Workaround because of NGC's TensorFlow version
+    class_names = get_classes(cfg.classes_path)
+    num_classes = len(class_names)
+    img_height, img_width = cfg.img_height, cfg.img_width
+    solo = SOLOModel(
+        input_shape=(img_height, img_width, 3),  # Example shape
+        num_classes=num_classes,
+        num_stacked_convs=7,
+        head_input_channels=256,
+        mask_kernel_channels=256,
+        grid_sizes=cfg.grid_sizes
+    )
+    solo.build((None, img_height, img_width, 3))
+    solo.load_weights(model_path)
 
     if not os.path.exists('images/res/'): os.mkdir('images/res/')
     path_dir = os.listdir('images/test')
@@ -401,7 +437,6 @@ if __name__ == '__main__':
             mask_feat=mask_feat,
             resized_image_shape=input_shape[:2],
             score_threshold=cfg.score_threshold,
-            include_background=cfg.include_background,
             nms_sigma=0.5
         )
 

--- a/test_dataset.py
+++ b/test_dataset.py
@@ -5,129 +5,146 @@ Description: This script draws dataset with masks by categories to understand wh
 """
 
 
-import cv2
 import os
-import numpy as np
-import tensorflow as tf
 from pycocotools.coco import COCO
+import tensorflow as tf
+import numpy as np
+import cv2
+import random
 
 from config import DynamicSOLOConfig
-from coco_dataset import create_coco_tf_dataset, get_classes
+from coco_dataset import create_coco_tf_dataset
+from coco_dataset_optimized import create_coco_tfrecord_dataset
 import shutil
 
-
-def save_masks_by_category(
-        image_tensor,
-        ms_targets,
-        category_names,
-        img_num,
-        out_dir="masks_output"
+def draw_solo_instances(
+    image,                 # tf.Tensor or np.ndarray, HxWx3, RGB, [0,1] or [0,255]
+    cate_target,           # tf.Tensor or np.ndarray, shape [sum(S_i^2)], int32, -1 for empty else category_id
+    mask_target,           # tf.Tensor or np.ndarray, shape [Hf, Wf, sum(S_i^2)], uint8 {0,1}
+    class_names=None,      # dict {category_id: "name"} (same role as in your snippet)
+    show_labels=True       # follow your snippet's switch
 ):
     """
-    For each scale in `ms_targets`, separate the mask channels by category and
-    save the results to disk in a folder structure like:
-        masks_output/
-          catName_0/
-            scale0_channel0.png
-            scale0_channel5.png
-            ...
-          catName_1/
-            scale1_channel3.png
-            ...
+    Returns a BGR uint8 visualization with colored masks and optional class labels.
+    Coloring, transparency and blending follow the behavior in draw_solo_masks():
+      - random color per instance
+      - alpha = 0.5
+      - vis[mask==1] = alpha*color + (1-alpha)*vis[mask==1]
+      - label near the first pixel of the mask
+    """
+
+    # --- to numpy ---
+    if isinstance(image, tf.Tensor):       image = image.numpy()
+    if isinstance(cate_target, tf.Tensor): cate_target = cate_target.numpy()
+    if isinstance(mask_target, tf.Tensor): mask_target = mask_target.numpy()
+
+    # --- image to uint8 BGR (so cv2.imwrite works as expected) ---
+    img = image.copy()
+    if img.dtype != np.uint8:
+        img = np.clip(img * 255.0, 0, 255).astype(np.uint8)
+    vis = cv2.cvtColor(img, cv2.COLOR_RGB2BGR)
+
+    H, W = vis.shape[:2]
+    Hf, Wf, C = mask_target.shape
+    assert C == cate_target.shape[0], "mask_target channels and cate_target length must match"
+
+    # Upsample all masks to image size using NEAREST (binary kept)
+    if (Hf != H) or (Wf != W):
+        up_masks = np.zeros((H, W, C), dtype=np.uint8)
+        for c in range(C):
+            up_masks[..., c] = cv2.resize(mask_target[..., c], (W, H), interpolation=cv2.INTER_NEAREST)
+    else:
+        up_masks = mask_target
+
+    # positive channels (instances)
+    pos_idx = np.where(cate_target >= 0)[0]
+    if pos_idx.size == 0:
+        return vis
+
+    alpha = 0.5
+
+    for ch in pos_idx:
+        class_id = int(cate_target[ch])
+        mask_bin = (up_masks[..., ch] > 0)
+
+        if mask_bin.sum() == 0:
+            continue
+
+        # Random color per instance (same principle as your snippet)
+        color = np.array([random.randint(0, 255) for _ in range(3)], dtype=np.float32)
+
+        # Per-pixel alpha blend exactly like:
+        # vis[mask==1] = alpha*color + (1-alpha)*vis[mask==1]
+        m = mask_bin
+        if m.any():
+            region = vis[m].astype(np.float32)
+            vis[m] = (alpha * color + (1.0 - alpha) * region).astype(np.uint8)
+
+        # Label near first pixel in the mask (if enabled)
+        if show_labels:
+            ys, xs = np.where(m)
+            if len(ys) > 0:
+                y0, x0 = int(ys[0]), int(xs[0])
+                if isinstance(class_names, dict) and (class_id in class_names):
+                    label_str = f"{class_names.get(class_id)}"
+                else:
+                    label_str = f"ID={class_id}"
+                cv2.putText(
+                    vis, label_str,
+                    (x0, y0),
+                    cv2.FONT_HERSHEY_SIMPLEX,
+                    0.5, (255, 255, 255), 1
+                )
+
+    return vis
+
+def save_dataset_preview(dataset, coco_classes, out_dir, max_images=50, show_labels=True):
+    """
+    Save a grid-free preview of SOLO targets for a dataset.
+
+    Iterates over a `tf.data.Dataset` that yields `(images, cate_targets, mask_targets)`
+    batches, renders each sample with `draw_solo_instances`, and writes PNG files to
+    `out_dir` until `max_images` previews are saved.
 
     Args:
-        image_tensor (tf.Tensor): shape=(H, W, 3), in [0,1].
-        ms_targets (dict): e.g. contains "cate_target_0", "mask_target_0", etc.
-        category_names(dict):
-                       a dict mapping category_id -> readable category name.
-        out_dir (str): root directory to save mask images.
+      dataset: `tf.data.Dataset` where each batch is a tuple:
+        - images: Tensor of shape (B, H, W, 3), RGB, float in [0,1] or uint8.
+        - cate_targets: Tensor of shape (B, C), int32; -1 for empty, category_id otherwise.
+        - mask_targets: Tensor of shape (B, Hf, Wf, C), uint8 {0,1}.
+      coco_classes: `dict[int, str]` mapping category_id → class name for labeling.
+      out_dir: Destination directory to store rendered PNG files.
+      max_images: Maximum number of samples to save across all batches.
+      show_labels: If True, overlay class labels on the previews.
+
+    Returns:
+      None
     """
-    # Make sure the output directory exists
+    import os, cv2
     os.makedirs(out_dir, exist_ok=True)
-
-    # Convert image to Numpy
-    image_np = image_tensor.numpy()  # shape=(H, W, 3)
-    img_h, img_w = image_np.shape[:2]
-
-    # Figure out the scale indices from ms_targets
-    scale_indices = []
-    for key in ms_targets.keys():
-        if key.startswith("mask_target_"):
-            idx = int(key.split("_")[-1])
-            scale_indices.append(idx)
-    scale_indices.sort()
-
-    # Loop over scales
-    for scale_idx in scale_indices:
-        cate_key = f"cate_target_{scale_idx}"
-        mask_key = f"mask_target_{scale_idx}"
-
-        cate_tensor = ms_targets[cate_key]  # shape=(grid_size, grid_size)
-        mask_tensor = ms_targets[mask_key]  # shape=(feat_h, feat_w, grid_size^2)
-
-        cate_np = cate_tensor[0].numpy()
-        mask_np = mask_tensor[0].numpy()
-
-        feat_h, feat_w, num_channels = mask_np.shape
-        grid_size = cate_np.shape[0]  # e.g. 40, 36, etc.
-
-        # Sanity check: grid_size^2 should match num_channels
-        assert grid_size * grid_size == num_channels, \
-            f"Mismatch: grid_size^2={grid_size * grid_size} vs mask channels={num_channels}"
-
-        # Iterate over each channel in mask_target
-        for ch in range(num_channels):
-            # Derive the grid cell (gy, gx) from channel index
-            gy = ch // grid_size
-            gx = ch % grid_size
-
-            cat_id = cate_np[gy, gx]
-            if cat_id == -1:
-                # No object in this cell
-                continue
-
-            # Get the mask for this channel
-            mask_ch = mask_np[..., ch]  # shape=(feat_h, feat_w)
-
-            # If the mask is all zeros, skip to avoid extra blank images
-            if np.max(mask_ch) == 0:
-                continue
-
-            # Resize mask to match the original (H, W)
-            # We use INTER_NEAREST to preserve the hard edges
-            mask_resized = cv2.resize(
-                mask_ch.astype(np.uint8),
-                (img_w, img_h),
-                interpolation=cv2.INTER_NEAREST
+    saved = 0
+    for batch in dataset:
+        images, cate_targets, mask_targets = batch
+        bs = images.shape[0]
+        for b in range(bs):
+            vis = draw_solo_instances(
+                images[b].numpy(),
+                cate_targets[b].numpy(),
+                mask_targets[b].numpy(),
+                class_names=coco_classes,
+                show_labels=show_labels
             )
+            cv2.imwrite(os.path.join(out_dir, f"sample_{saved:04d}.png"), vis)
+            saved += 1
+            if saved >= max_images:
+                return
 
-            # Prepare an overlay or just the masked region
-            # Here we show an example overlay in red
-            overlay_color = (1.0, 0.0, 0.0)  # Red in [0,1]
-            overlay = image_np.copy()
-
-            # Make a colored overlay wherever mask==1
-            # If you prefer pure mask, skip the overlay logic
-            overlay[mask_resized > 0] = overlay_color
-
-            # Convert overlay to 8-bit
-            overlay_8u = (overlay * 255).astype(np.uint8)
-
-            # Create category folder
-            # If you have a dict or list of category_names, do something like:
-            cat_name = category_names.get(cat_id) if cat_id < len(category_names) else f"cat_{cat_id}"
-            cat_dir = os.path.join(out_dir, cat_name)
-            os.makedirs(cat_dir, exist_ok=True)
-
-            # Construct a filename
-            # Example: scale0_channel12.png
-            out_filename = f"img_{img_num}_scale{scale_idx}_channel{ch}.png"
-            out_path = os.path.join(cat_dir, out_filename)
-
-            # Save to disk
-            cv2.imwrite(out_path, cv2.cvtColor(overlay_8u, cv2.COLOR_RGB2BGR))
-
-    print(f"Masks saved under '{out_dir}' separated by category.")
+gpus = tf.config.experimental.list_physical_devices('GPU')
+if gpus:
+    try:
+        for gpu in gpus:
+            tf.config.experimental.set_memory_growth(gpu, False)
+    except RuntimeError as e:
+        print(e)
 
 if __name__ == '__main__':
     cfg = DynamicSOLOConfig()
@@ -139,22 +156,33 @@ if __name__ == '__main__':
     num_classes = len(coco_classes)
     img_height, img_width = cfg.img_height, cfg.img_width
 
-    ds = create_coco_tf_dataset(
-        coco_annotation_file=cfg.train_annotation_path,
-        coco_img_dir=cfg.images_path,
-        num_classes=num_classes,
-        target_size=(img_height, img_width),
-        batch_size=1,
-        grid_sizes=cfg.grid_sizes,
-        scale=cfg.image_scales[0],
-        augment=False,
-        number_images=20
-    )
+    if cfg.use_optimized_dataset:
+        ds = create_coco_tfrecord_dataset(
+            train_tfrecord_directory=cfg.tfrecord_dataset_directory_path,
+            target_size=(img_height, img_width),
+            batch_size=cfg.batch_size,
+            grid_sizes=cfg.grid_sizes,
+            scale=cfg.image_scales[0],
+            augment=cfg.augment,
+            shuffle_buffer_size=cfg.shuffle_buffer_size,
+            number_images=cfg.number_images)
+    else:
+        ds = create_coco_tf_dataset(
+            coco_annotation_file=cfg.train_annotation_path,
+            coco_img_dir=cfg.images_path,
+            target_size=(img_height, img_width),
+            batch_size=cfg.batch_size,
+            grid_sizes=cfg.grid_sizes,
+            scale=cfg.image_scales[0],
+            augment=False,
+            number_images=cfg.number_images
+        )
 
     out_dir = 'images/dataset_test'
     shutil.rmtree(out_dir, ignore_errors=True)
 
-    for img_num, (image_tensor, ms_targets) in enumerate(ds):
-        save_masks_by_category(image_tensor[0], ms_targets, category_names=coco_classes, img_num=img_num, out_dir=out_dir)
+    os.makedirs(out_dir, exist_ok=True)
+    save_dataset_preview(ds, coco_classes, out_dir, max_images=200)  # adjust as needed
+    print(f"Saved previews to: {out_dir}")
 
 

--- a/train.py
+++ b/train.py
@@ -6,12 +6,12 @@ Description: This script performs the main actions for the training process.
 
 
 import os
-import keras
 import logging
 import re
 import tensorflow as tf
 import tensorflow.keras.layers as layers
 from coco_dataset import create_coco_tf_dataset, get_classes
+from coco_dataset_optimized import create_coco_tfrecord_dataset
 from config import DynamicSOLOConfig
 from model_functions import SOLOModel
 from loss import compute_multiscale_loss
@@ -35,39 +35,250 @@ if gpus:
 os.environ["TF_GPU_ALLOCATOR"] = "cuda_malloc_async"
 
 def extract_epoch_number(file_name):
+    """
+    Extract the epoch number from a saved Keras weight filename.
+    Expects filenames that match the pattern `"...epoch{N}.keras"`.
+
+    Args:
+      file_name (str): Filename to parse, e.g. `"solo_epoch00000042.keras"`.
+
+    Returns:
+      int: The extracted epoch number.
+    """
     return int(re.search(r'epoch(\d+)\.keras', file_name).group(1))
 
 def train_one_epoch(model, dataset, optimizer, num_classes):
     """
-    model: a tf.keras.Model (e.g., MultiScaleSOLO).
-    dataset: a tf.data.Dataset yielding (images, multi_scale_targets).
-    optimizer: e.g., tf.keras.optimizers.Adam or SGD.
+    Run one training epoch without gradient accumulation.
 
-    We'll compute the multi-scale loss and update model weights each step.
+    Iterates over the dataset once, computes loss, applies gradients, and prints
+    per-step metrics.
+
+    Args:
+      model (tf.keras.Model): SOLO model whose forward pass returns
+        `(class_outputs, mask_outputs, mask_feat)`, where:
+          * `class_outputs`: `[B, sum(S_i^2) num_classes]`
+          * `mask_outputs`: `[B, sum(S_i^2), D]`
+          * `mask_feat`: `[B, H, W, D]`
+        (`S` varies per FPN scale; `D` is the mask feature dimension).
+      dataset (tf.data.Dataset): Yields triples
+        `(images, cate_target, mask_target)` per step where:
+          * `images`: tf.float32, `[B, H, W, 3]`.
+          * `cate_target` (aka `class_target`): tf.int32 class indices per grid cell, `[B, sum(S_i^2)]`.
+          * `mask_target`: tf.uint8 GT masks aligned to grid cells, `[B, H, W, sum(S_i^2)]`.
+      optimizer (tf.keras.optimizers.Optimizer): Optimizer to update weights.
+      num_classes (int): Number of object classes (background excluded).
+
+    Returns:
+      None
     """
-    for step, (images, targets) in enumerate(dataset):
-        total_loss, cate_loss, mask_loss = train_one_step(model, images, targets, optimizer, num_classes)
+    for step, (images, cate_target, mask_target)  in enumerate(dataset):
+        total_loss, cate_loss, mask_loss = train_one_step(model, images, cate_target, mask_target, optimizer, num_classes)
         print("Step ", step, ": ", "total=", total_loss.numpy(), ", cate=", cate_loss.numpy(), ", mask=", mask_loss.numpy())
 
 @tf.function
-def train_one_step(model, images, targets, optimizer, num_classes):
+def train_one_step(model, images, cate_target, mask_target, optimizer, num_classes):
     """
-    model: a tf.keras.Model (e.g., MultiScaleSOLO).
-    dataset: a tf.data.Dataset yielding (images, multi_scale_targets).
-    optimizer: e.g., tf.keras.optimizers.Adam or SGD.
+    Perform a single optimization step (no accumulation).
 
-    We'll compute the multi-scale loss and update model weights each step.
+    Runs a forward pass, computes multiscale SOLO losses, backpropagates, and
+    applies gradients.
+
+    Args:
+      model (tf.keras.Model): SOLO model producing:
+        * `class_outputs`: `[B, sum(S_i^2), num_classes]`
+        * `mask_outputs`: `[B, sum(S_i^2), D]`
+        * `mask_feat`: `[B, H, W, D]`.
+      images (tf.Tensor): float32 input images, `[B, H, W, 3]`.
+      cate_target (tf.Tensor): Class indices per grid cell (a.k.a.
+        `class_target`), `[B, sum(S_i^2)]`.
+      mask_target (tf.Tensor): GT masks aligned to grid cells,
+        `[B, H, W, sum(S_i^2)]`.
+      optimizer (tf.keras.optimizers.Optimizer): Optimizer instance.
+      num_classes (int | tf.Tensor): Number of classes (background excluded).
+
+    Returns:
+      Tuple[tf.Tensor, tf.Tensor, tf.Tensor]:
+        * `total_loss`: scalar total loss.
+        * `cate_loss`: scalar classification (focal) loss.
+        * `mask_loss`: scalar mask (Dice) loss.
     """
     with tf.GradientTape() as tape:
-        outputs = model(images, training=True)
+        class_outputs, mask_outputs, mask_feat = model(images, training=True)
         total_loss, cate_loss, mask_loss = compute_multiscale_loss(
-            outputs,
-            targets,
-            num_scales=int(len(targets) / 2),
+            class_outputs, mask_outputs, mask_feat,
+            cate_target, mask_target,
             num_classes=tf.constant(num_classes))
     grads = tape.gradient(total_loss, model.trainable_variables)
     optimizer.apply_gradients(zip(grads, model.trainable_variables))
     return total_loss, cate_loss, mask_loss
+
+@tf.function
+def accumulate_one_step(model,
+                        images,
+                        cate_target,
+                        mask_target,
+                        num_classes,
+                        accum_grads):
+    """
+    Accumulate gradients for one mini-batch (no optimizer step).
+
+    Computes SOLO multiscale losses and adds gradients into preallocated
+    buffers to enable gradient accumulation across multiple steps.
+
+    Args:
+      model (tf.keras.Model): SOLO model producing:
+        * `class_outputs`: `[B, sum(S_i^2), num_classes]`
+        * `mask_outputs`: `[B, sum(S_i^2), D]`
+        * `mask_feat`: `[B, H, W, D]`.
+      images (tf.Tensor): float32 `[B, H, W, 3]`.
+      cate_target (tf.Tensor): Class indices `[B, sum(S_i^2)]`.
+      mask_target (tf.Tensor): GT masks `[B, H, W, sum(S_i^2)]`.
+      num_classes (int | tf.Tensor): Number of classes (background excluded).
+      accum_grads (List[tf.Variable]): Zero-initialized gradient buffers, one per entry in `model.trainable_variables`; same shapes/dtypes.
+
+    Returns:
+      Tuple[tf.Tensor, tf.Tensor, tf.Tensor]:
+        * `total_l`: scalar total loss.
+        * `cate_l`: scalar classification loss.
+        * `mask_l`: scalar mask loss.
+    """
+    with tf.GradientTape() as tape:
+        class_outputs, mask_outputs, mask_feat = model(images, training=True)
+        total_l, cate_l, mask_l = compute_multiscale_loss(
+            class_outputs, mask_outputs, mask_feat,
+            cate_target, mask_target,
+            num_classes=tf.constant(num_classes)
+        )
+
+    grads = tape.gradient(total_l, model.trainable_variables)
+
+    # add to buffers
+    for g_acc, g in zip(accum_grads, grads):
+        if g is not None:
+            g_acc.assign_add(g)
+
+    return total_l, cate_l, mask_l
+
+@tf.function
+def train_one_epoch_accumulated_mode(model,
+                    dataset,
+                    optimizer,
+                    num_classes,
+                    accumulation_steps,
+                    accum_grads,
+                    accum_counter,
+                    global_step):
+    """
+    Run one epoch with gradient accumulation using preallocated buffers.
+
+    For each batch, compute SOLO multiscale losses and add gradients to
+    `accum_grads`. Apply an optimizer step every `accumulation_steps` by
+    dividing buffered grads by `accumulation_steps` and resetting buffers.
+    Any leftover buffered grads at epoch end are cleared (no update).
+
+    Args:
+      model (tf.keras.Model): SOLO model producing:
+        * `class_outputs`: `[B, sum(S_i^2), num_classes]`
+        * `mask_outputs`: `[B, sum(S_i^2), D]`
+        * `mask_feat`: `[B, H, W, D]`.
+      dataset (tf.data.Dataset): Yields
+        `(images, cate_target, mask_target)` with shapes:
+        * `images`: `[B, H, W, 3]` (float32)
+        * `cate_target`: `[B, sum(S_i^2)]`
+        * `mask_target`: `[B, H, W, sum(S_i^2)]`.
+      optimizer (tf.keras.optimizers.Optimizer): Optimizer instance.
+      num_classes (int | tf.Tensor): Number of classes (background excluded).
+      accumulation_steps (int): Number of mini-batches to accumulate.
+      accum_grads (List[tf.Variable]): Gradient buffers (zeros, same shapes as `model.trainable_variables`).
+      accum_counter (tf.Variable): int32 counter tracking steps since last apply.
+      global_step (tf.Variable): int32 counter of total steps in the epoch.
+
+    Returns:
+      None
+    """
+
+    # helper: apply optimiser + reset buffers
+    def _apply_and_reset(denominator):
+        scaled = [g / tf.cast(denominator, g.dtype) for g in accum_grads]
+        optimizer.apply_gradients(zip(scaled, model.trainable_variables))
+        for g in accum_grads:
+            g.assign(tf.zeros_like(g))
+        accum_counter.assign(0)
+
+    def _reset_counter():
+        for g in accum_grads:
+            g.assign(tf.zeros_like(g))
+        accum_counter.assign(0)
+
+    for images, cate_target, mask_target in dataset:                     # AutoGraph → while_loop
+        tot, cat, msk = accumulate_one_step(
+            model, images, cate_target, mask_target, num_classes, accum_grads)
+
+        accum_counter.assign_add(1)
+        global_step.assign_add(1)
+
+        tf.cond(accum_counter == accumulation_steps,
+                lambda: _apply_and_reset(accumulation_steps),
+                lambda: None)
+
+        tf.print("step", global_step,
+                 ": total =", tot,
+                 "cate =", cat,
+                 "mask =", msk)
+
+    # flush leftovers
+    tf.cond(accum_counter > 0,
+            lambda: _reset_counter(),
+            lambda: None)
+
+def run_one_epoch_accumulated_mode(model,
+                  dataset,
+                  optimizer,
+                  num_classes,
+                  accumulation_steps=8):
+    """
+    Convenience wrapper to run one epoch with gradient accumulation.
+
+    Allocates zero-initialized gradient buffers and integer counters, then
+    calls :func:`train_one_epoch_accumulated_mode`.
+
+    Args:
+      model (tf.keras.Model): SOLO model producing:
+        * `class_outputs`: `[B, sum(S_i^2), num_classes]`
+        * `mask_outputs`: `[B, sum(S_i^2), D]`
+        * `mask_feat`: `[B, H, W, D]`.
+      dataset (tf.data.Dataset): Yields
+        `(images, cate_target, mask_target)` with shapes:
+        * `images`: `[B, H, W, 3]` (float32)
+        * `cate_target`: `[B, sum(S_i^2)]`
+        * `mask_target`: `[B, H, W, sum(S_i^2)]`.
+      optimizer (tf.keras.optimizers.Optimizer): Optimizer instance.
+      num_classes (int): Number of classes (background excluded).
+      accumulation_steps (int, optional): Steps to accumulate before applying updates. Defaults to `8`.
+
+    Returns:
+      None
+    """
+    # gradient buffers (one per trainable weight)
+    accum_grads = [
+        tf.Variable(tf.zeros_like(v), trainable=False)
+        for v in model.trainable_variables
+    ]
+
+    # counters
+    accum_counter = tf.Variable(0, dtype=tf.int32, trainable=False)
+    global_step   = tf.Variable(0, dtype=tf.int32, trainable=False)
+
+    # run the compiled graph
+    train_one_epoch_accumulated_mode(model,
+                    dataset,
+                    optimizer,
+                    num_classes,
+                    accumulation_steps,
+                    accum_grads,
+                    accum_counter,
+                    global_step)
 
 
 if __name__ == '__main__':
@@ -82,41 +293,66 @@ if __name__ == '__main__':
     # load previous model if load_previous_model = True
     load_previous_model = cfg.load_previous_model
     if load_previous_model:
-        solo_model = keras.models.load_model(cfg.model_path)
+        # Create a model instance because of NGC's TensorFlow version
+        solo_model = SOLOModel(
+            input_shape=(img_height, img_width, 3),  # Example shape
+            num_classes=num_classes,
+            num_stacked_convs=7,
+            head_input_channels=256,
+            mask_kernel_channels=256,
+            grid_sizes=cfg.grid_sizes
+        )
+        solo_model.build((None, img_height, img_width, 3))
+        solo_model.load_weights(cfg.model_path)
         previous_epoch = extract_epoch_number(cfg.model_path)
     else:
         solo_model = SOLOModel(
             input_shape=(img_height, img_width, 3),  # Example shape
             num_classes=num_classes,
-            num_stacked_convs=4,
+            num_stacked_convs=7,
             head_input_channels=256,
             mask_kernel_channels=256,
             grid_sizes=cfg.grid_sizes
         )
+        solo_model.build((None, img_height, img_width, 3))
 
     if previous_epoch > cfg.epochs:
         print(f'The model is trained {previous_epoch} epochs already while configuration assumes {cfg.epochs} epochs.')
         exit(0)
 
     # Form COCO dataset
-    ds = create_coco_tf_dataset(
-        coco_annotation_file=cfg.train_annotation_path,
-        coco_img_dir=cfg.images_path,
-        num_classes=num_classes,
-        target_size=(img_height, img_width),
-        batch_size=cfg.batch_size,
-        grid_sizes=cfg.grid_sizes,
-        scale=cfg.image_scales[0],
-        number_images=cfg.number_images
-    )
+    if cfg.use_optimized_dataset:
+        ds = create_coco_tfrecord_dataset(
+            train_tfrecord_directory=cfg.tfrecord_dataset_directory_path,
+            target_size=(img_height, img_width),
+            batch_size=cfg.batch_size,
+            grid_sizes=cfg.grid_sizes,
+            scale=cfg.image_scales[0],
+            augment=cfg.augment,
+            shuffle_buffer_size=cfg.shuffle_buffer_size,
+            number_images=cfg.number_images)
+    else:
+        ds = create_coco_tf_dataset(
+            coco_annotation_file=cfg.train_annotation_path,
+            coco_img_dir=cfg.images_path,
+            target_size=(img_height, img_width),
+            batch_size=cfg.batch_size,
+            grid_sizes=cfg.grid_sizes,
+            scale=cfg.image_scales[0],
+            number_images=cfg.number_images,
+            augment=cfg.augment
+        )
 
-    optimizer = tf.keras.optimizers.Adam(learning_rate=cfg.lr)
+    optimizer = tf.keras.optimizers.SGD(learning_rate=cfg.lr, momentum=0.9)
 
     # Training loop
     print("Starting training...")
     for epoch in range(previous_epoch + 1, cfg.epochs):
         print(f"Starting epoch {epoch}:")
-        train_one_epoch(solo_model, ds, optimizer, num_classes)
+        if cfg.use_gradient_accumulation_steps:
+            run_one_epoch_accumulated_mode(solo_model, ds, optimizer, num_classes, accumulation_steps=cfg.accumulation_steps)
+        else:
+            train_one_epoch(solo_model, ds, optimizer, num_classes)
         # ==================== save ====================
         if epoch != 0 and epoch % cfg.save_iter == 0:
             save_path = f'./weights/{cfg.model_weights_prefix}_epoch%.8d.keras' % epoch


### PR DESCRIPTION
- Changed coco_dataset so that it no longer uses dictionaries as output. It now returns a concatenated category tensor and a concatenated mask tensor.
- Added the optimized version of the dataset that works with TFRecord files: coco_dataset_optimized.py
- Added the ability to run training steps in gradient accumulation mode, where the gradient for the loss function is accumulated over several iteration steps.
- Introduced convert_coco_to_tfrecord.py for COCO dataset conversion to TFRecord format
- Replaced the model output, which was a list of tensors with concatenated tensors.
- Changed focal_loss significantly to provide more stable and robust convergence.
- Changed dice_loss to improve performance.
- Overall, changed the loss function calculation due to changes in the model output and dataset instance format.
- Changed test_dataset so that it draws the entire image with all instance masks and labels together for clearer visualization.
- Optimized inference process
- Added new options related to accumulated gradient mode and the new optimized dataset in config.py
- Added instructions for converting COCO dataset to TFRecord files and instructions for using the new optimized dataset in ReadMe.md
- Added `pillow` to requirements.txt